### PR TITLE
fix: Android以外ではhighlightActiveLine()を有効化

### DIFF
--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -343,7 +343,9 @@
       dropCursor(),
       rectangularSelection(),
       crosshairCursor(),
-      // highlightActiveLine(), // Gboardと相性が悪いため除外
+      // Android + Gboard環境では、highlightActiveLine() がデコレーション更新時にDOMを変更し、
+      // ネイティブの範囲選択が段落境界で強制解除されるバグがある
+      ...(/android/i.test(navigator.userAgent) ? [] : [highlightActiveLine()]),
       markdown(),
       history(),
       keymap.of([...defaultKeymap, ...historyKeymap]),


### PR DESCRIPTION
mypaceと同じアプローチに統一。以前は全環境で無条件に除外していたが、
Android + Gboard環境のみ条件付きで除外し、デスクトップでは
アクティブ行ハイライト機能を維持するように変更。

https://claude.ai/code/session_011Hmj9b434Zu5KNUSU6iFbP