### PR TITLE
fix: 起動時の白画面を修正

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import './App.css'
-  import { waitForSwCheck } from './main'
+  import { waitForSwCheck } from './lib/sw-check'
   import { onMount, tick, setContext } from 'svelte'
   import { writable, get } from 'svelte/store'
   import type { Note, Leaf, Breadcrumb, View, Metadata, WorldType, SearchMatch } from './lib/types'
@@ -688,12 +688,13 @@
       const loadedSettings = loadSettings()
       settings.set(loadedSettings)
 
+      // テーマを先に適用（ローディング画面のバックグラウンドカラーに反映させるため）
+      applyTheme(loadedSettings.theme, loadedSettings)
+      document.title = loadedSettings.toolName
+
       // i18n初期化（翻訳読み込み完了を待機）
       await initI18n(loadedSettings.locale)
       i18nReady = true
-
-      applyTheme(loadedSettings.theme, loadedSettings)
-      document.title = loadedSettings.toolName
 
       // オフラインリーフを読み込み（GitHub設定に関係なく常に利用可能）
       const savedOfflineLeaf = await loadOfflineLeaf(OFFLINE_LEAF_ID)

--- a/src/components/views/HomeView.svelte
+++ b/src/components/views/HomeView.svelte
@@ -209,7 +209,15 @@
     {/if}
 
     <!-- ノートカード: 特殊リーフの後に表示 -->
-    {#if notes.length === 0 && isFirstPriorityFetched}
+    {#if notes.length === 0 && !isFirstPriorityFetched && !isArchive}
+      <div class="fetch-loading-state">
+        <div class="fetch-loading-dots">
+          <span class="fetch-dot">.</span>
+          <span class="fetch-dot">.</span>
+          <span class="fetch-dot">.</span>
+        </div>
+      </div>
+    {:else if notes.length === 0 && isFirstPriorityFetched}
       <div class="empty-state">
         <p>{isArchive ? $_('home.noNotesArchive') : $_('home.noNotes')}</p>
       </div>
@@ -275,6 +283,47 @@
     margin: 0;
     opacity: 0.8;
     white-space: pre-line;
+  }
+
+  .fetch-loading-state {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .fetch-loading-dots {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .fetch-dot {
+    font-size: 2.5rem;
+    color: var(--accent);
+    animation: fetch-pulse 1.5s ease-in-out infinite;
+  }
+
+  .fetch-dot:nth-child(2) {
+    animation-delay: 0.3s;
+  }
+
+  .fetch-dot:nth-child(3) {
+    animation-delay: 0.6s;
+  }
+
+  @keyframes fetch-pulse {
+    0%,
+    100% {
+      opacity: 0.3;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 1;
+      transform: scale(1.2);
+    }
   }
 
   /* リーフカード（NoteViewと同じスタイル） */

--- a/src/lib/sw-check.ts
+++ b/src/lib/sw-check.ts
@@ -1,0 +1,94 @@
+import { registerSW } from 'virtual:pwa-register'
+
+/**
+ * PWA更新チェック完了を待つためのPromise
+ * App.svelteのonMountで初回Pullより先にこのPromiseをawaitする
+ *
+ * main.ts → App.svelte の循環インポートを避けるため独立モジュールに分離
+ */
+export const waitForSwCheck: Promise<void> = new Promise((resolve) => {
+  let resolved = false
+  const safeResolve = () => {
+    if (!resolved) {
+      resolved = true
+      resolve()
+    }
+  }
+
+  const updateSW = registerSW({
+    immediate: true,
+    onRegistered(swRegistration) {
+      if (swRegistration) {
+        // SW登録完了 → 更新チェック開始
+        // update()はPromiseを返すので、完了を待ってから少し待機
+        // この間にonNeedRefreshが呼ばれれば、リロードされる
+        swRegistration
+          .update()
+          .then(() => {
+            // 更新チェック完了後、onNeedRefreshが呼ばれる猶予を与える
+            setTimeout(safeResolve, 500)
+          })
+          .catch((error) => {
+            // オフライン時やネットワークエラー時も続行
+            console.log('SW update check skipped:', error?.message || 'offline')
+            safeResolve()
+          })
+      } else {
+        // SW未対応環境
+        safeResolve()
+      }
+    },
+    onNeedRefresh() {
+      // 新しいSWが検知された場合、メッセージを表示してからリロード
+      console.log('New version available, reloading...')
+
+      // 画面中央にオーバーレイを表示
+      const overlay = document.createElement('div')
+      overlay.style.cssText = `
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.8);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 99999;
+      `
+
+      const message = document.createElement('div')
+      message.style.cssText = `
+        color: white;
+        font-size: 0.9rem;
+        text-align: center;
+        padding: 1.5rem 2rem;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 8px;
+        backdrop-filter: blur(10px);
+      `
+      const isJapanese = navigator.language.startsWith('ja')
+      message.textContent = isJapanese
+        ? '新しいバージョンがあります。再起動します...'
+        : 'New version available. Restarting...'
+
+      overlay.appendChild(message)
+      document.body.appendChild(overlay)
+
+      // 1.5秒後にリロード
+      setTimeout(() => {
+        // updateSW(true)でskipWaitingを発火させてからリロード
+        updateSW(true)
+        // 少し待ってからリロード（SWの切り替えを待つ）
+        setTimeout(() => {
+          window.location.reload()
+        }, 100)
+      }, 1500)
+      // resolveは呼ばない（リロードするので不要）
+    },
+  })
+
+  // タイムアウト: SWがサポートされていない環境や登録に時間がかかる場合
+  // 2秒以内に更新チェックが完了しなければ続行
+  setTimeout(safeResolve, 2000)
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,95 +1,9 @@
 import './App.css'
 import App from './App.svelte'
-import { registerSW } from 'virtual:pwa-register'
 
-// PWA更新チェック完了を待つためのPromise
-// App.svelteのonMountで初回Pullより先にこのPromiseをawaitする
-export const waitForSwCheck: Promise<void> = new Promise((resolve) => {
-  let resolved = false
-  const safeResolve = () => {
-    if (!resolved) {
-      resolved = true
-      resolve()
-    }
-  }
-
-  const updateSW = registerSW({
-    immediate: true,
-    onRegistered(swRegistration) {
-      if (swRegistration) {
-        // SW登録完了 → 更新チェック開始
-        // update()はPromiseを返すので、完了を待ってから少し待機
-        // この間にonNeedRefreshが呼ばれれば、リロードされる
-        swRegistration
-          .update()
-          .then(() => {
-            // 更新チェック完了後、onNeedRefreshが呼ばれる猶予を与える
-            setTimeout(safeResolve, 500)
-          })
-          .catch((error) => {
-            // オフライン時やネットワークエラー時も続行
-            console.log('SW update check skipped:', error?.message || 'offline')
-            safeResolve()
-          })
-      } else {
-        // SW未対応環境
-        safeResolve()
-      }
-    },
-    onNeedRefresh() {
-      // 新しいSWが検知された場合、メッセージを表示してからリロード
-      console.log('New version available, reloading...')
-
-      // 画面中央にオーバーレイを表示
-      const overlay = document.createElement('div')
-      overlay.style.cssText = `
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.8);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        z-index: 99999;
-      `
-
-      const message = document.createElement('div')
-      message.style.cssText = `
-        color: white;
-        font-size: 0.9rem;
-        text-align: center;
-        padding: 1.5rem 2rem;
-        background: rgba(255, 255, 255, 0.1);
-        border-radius: 8px;
-        backdrop-filter: blur(10px);
-      `
-      const isJapanese = navigator.language.startsWith('ja')
-      message.textContent = isJapanese
-        ? '新しいバージョンがあります。再起動します...'
-        : 'New version available. Restarting...'
-
-      overlay.appendChild(message)
-      document.body.appendChild(overlay)
-
-      // 1.5秒後にリロード
-      setTimeout(() => {
-        // updateSW(true)でskipWaitingを発火させてからリロード
-        updateSW(true)
-        // 少し待ってからリロード（SWの切り替えを待つ）
-        setTimeout(() => {
-          window.location.reload()
-        }, 100)
-      }, 1500)
-      // resolveは呼ばない（リロードするので不要）
-    },
-  })
-
-  // タイムアウト: SWがサポートされていない環境や登録に時間がかかる場合
-  // 2秒以内に更新チェックが完了しなければ続行
-  setTimeout(safeResolve, 2000)
-})
+// SW更新チェックは独立モジュールに分離（循環インポート防止）
+// App.svelte から直接 './lib/sw-check' をインポートして使用する
+import './lib/sw-check'
 
 const app = new App({
   target: document.getElementById('app') as HTMLElement,


### PR DESCRIPTION
- main.ts と App.svelte 間の循環インポートを解消（waitForSwCheck を独立モジュール src/lib/sw-check.ts に分離）
- テーマ適用を i18n 初期化より前に移動し、ローディング画面に正しい背景色を反映
- HomeView にデータ取得中のローディングインジケータを追加（isFirstPriorityFetched が false の間）

https://claude.ai/code/session_01Mde7m46LtEutJbFiR4S2s9