### PR TITLE
feat: 検索デバウンス導入

### DIFF
--- a/src/components/layout/SearchBar.svelte
+++ b/src/components/layout/SearchBar.svelte
@@ -30,6 +30,7 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
       e.preventDefault()
+      localQuery = ''
       clearSearch() // クエリをクリア
       closeSearch()
       inputElement?.blur()

--- a/src/lib/utils/search.svelte.ts
+++ b/src/lib/utils/search.svelte.ts
@@ -326,11 +326,18 @@ export function getLineNumber(content: string, charIndex: number): number {
 
 // ========== ハンドラー ==========
 
+let _debounceTimer: ReturnType<typeof setTimeout> | null = null
+const DEBOUNCE_MS = 250
+
 export function openSearch(): void {
   isSearchOpen.value = true
 }
 
 export function closeSearch(): void {
+  if (_debounceTimer) {
+    clearTimeout(_debounceTimer)
+    _debounceTimer = null
+  }
   isSearchOpen.value = false
   // 検索クエリはクリアしない（ユーザーが明示的にクリアするまで保持）
   selectedResultIndex.value = -1
@@ -345,12 +352,13 @@ export function toggleSearch(): void {
 }
 
 export function clearSearch(): void {
+  if (_debounceTimer) {
+    clearTimeout(_debounceTimer)
+    _debounceTimer = null
+  }
   searchQuery.value = ''
   selectedResultIndex.value = -1
 }
-
-let _debounceTimer: ReturnType<typeof setTimeout> | null = null
-const DEBOUNCE_MS = 250
 
 export function handleSearchInput(query: string): void {
   if (_debounceTimer) clearTimeout(_debounceTimer)


### PR DESCRIPTION
## 関連 Issue
closes #50

## 変更内容
- `handleSearchInput` に250msデバウンスを導入
- SearchBar にローカル入力値（`localQuery`）を追加し、UI表示は即座に反映しつつストア更新のみ遅延させる
- 型チェック・lint 0エラー