### PR TITLE
feat: ノートカードのノート名左にフォルダアイコンを追加

### DIFF
--- a/src/components/cards/NoteCard.svelte
+++ b/src/components/cards/NoteCard.svelte
@@ -63,13 +63,13 @@
     <span class="dirty-indicator" title={$_('note.hasUnsavedLeaves')}></span>
   {/if}
   <BadgeButton icon={badgeIcon} color={badgeColor} onChange={onBadgeChange} />
-  <strong class="note-title">
+  <div class="note-title">
     <svg class="folder-icon" viewBox="0 0 20 20" aria-hidden="true">
       <path
         d="M2 5a2 2 0 0 1 2-2h3.586A2 2 0 0 1 9 3.586L10.414 5H16a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5Z"
       />
-    </svg><span class="note-name text-ellipsis">{note.name}</span></strong
-  >
+    </svg><strong class="note-name text-ellipsis">{note.name}</strong>
+  </div>
   <div class="card-meta">
     {#each items as item}
       <small class="note-item text-ellipsis">{item}</small>
@@ -93,15 +93,11 @@
     max-height: 150px;
   }
 
-  .note-card strong {
-    max-width: 100%;
-    margin-bottom: 0.5rem;
-  }
-
   .note-title {
     display: flex;
     align-items: center;
     gap: 0.3em;
+    margin-bottom: 0.5rem;
   }
 
   .note-name {


### PR DESCRIPTION
## 関連 Issue
closes #66

## 変更内容
- `NoteCard.svelte` のノート名左にインラインSVGのフォルダアイコンを追加
- 色は `var(--accent)`（テーマカラーに自動追従）
- リーフカードは変更なし