### PR TITLE
fix: テーマカラーの視認性改善とwhiteboard差別化

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,18 +14,19 @@ All colors are CSS custom properties, dynamically computed via `color-mix()`.
 
 ### Core Variables
 
-| Variable          | Derivation            | Usage                    |
-| ----------------- | --------------------- | ------------------------ |
-| `--bg`            | Theme-defined         | Page background          |
-| `--text`          | Theme-defined         | Primary text             |
-| `--accent`        | Theme-defined         | Brand, links, selection  |
-| `--error`         | Theme-defined         | Error states             |
-| `--selection`     | `accent 35% + bg 65%` | Text selection highlight |
-| `--text-muted`    | `text 70% + bg 30%`   | Secondary text           |
-| `--surface-1`     | `bg 92% + text 8%`    | Card backgrounds         |
-| `--surface-2`     | `bg 86% + text 14%`   | Badge backgrounds        |
-| `--border`        | `text 15% + bg 85%`   | Standard borders         |
-| `--border-strong` | `text 25% + bg 75%`   | Input borders, toggles   |
+| Variable             | Derivation            | Usage                               |
+| -------------------- | --------------------- | ----------------------------------- |
+| `--bg`               | Theme-defined         | Page background                     |
+| `--text`             | Theme-defined         | Primary text                        |
+| `--accent`           | Theme-defined         | Brand, links, selection             |
+| `--error`            | Theme-defined         | Error states                        |
+| `--selection`        | `accent 35% + bg 65%` | Text selection highlight            |
+| `--selection-active` | `accent 50% + bg 50%` | Selection on active line (stronger) |
+| `--text-muted`       | `text 70% + bg 30%`   | Secondary text                      |
+| `--surface-1`        | `bg 92% + text 8%`    | Card backgrounds                    |
+| `--surface-2`        | `bg 86% + text 14%`   | Badge backgrounds                   |
+| `--border`           | `text 15% + bg 85%`   | Standard borders                    |
+| `--border-strong`    | `text 25% + bg 75%`   | Input borders, toggles              |
 
 ### Theme Definitions
 
@@ -34,7 +35,7 @@ All colors are CSS custom properties, dynamically computed via `color-mix()`.
 | default    | `#fdfdfc` | `#1f2933` | `#c7a443` | `#b42318` | Warm neutral    |
 | campus     | `#fdf8ec` | `#1f2937` | `#2f56c6` | `#b42318` | Academic blue   |
 | greenboard | `#102117` | `#e6f0e7` | `#96d46a` | `#ff9f9f` | Dark chalkboard |
-| whiteboard | `#ffffff` | `#1f2933` | `#3b82f6` | `#b42318` | Clean white     |
+| whiteboard | `#e8e8e8` | `#1f2933` | `#3b82f6` | `#b42318` | Clean white     |
 | dotsD      | `#05080f` | `#e2ecff` | `#666666` | `#f472b6` | Dark modern     |
 | dotsF      | `#0000aa` | `#ffffff` | `#5ca8ff` | `#ff6666` | Retro neon      |
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,19 +14,18 @@ All colors are CSS custom properties, dynamically computed via `color-mix()`.
 
 ### Core Variables
 
-| Variable             | Derivation              | Usage                               |
-| -------------------- | ----------------------- | ----------------------------------- |
-| `--bg`               | Theme-defined           | Page background                     |
-| `--text`             | Theme-defined           | Primary text                        |
-| `--accent`           | Theme-defined           | Brand, links, selection             |
-| `--error`            | Theme-defined           | Error states                        |
-| `--selection`        | `accent 35% + bg 65%`   | Text selection highlight            |
-| `--selection-active` | `accent 80% + text 20%` | Selection on active line (stronger) |
-| `--text-muted`       | `text 70% + bg 30%`     | Secondary text                      |
-| `--surface-1`        | `bg 92% + text 8%`      | Card backgrounds                    |
-| `--surface-2`        | `bg 86% + text 14%`     | Badge backgrounds                   |
-| `--border`           | `text 15% + bg 85%`     | Standard borders                    |
-| `--border-strong`    | `text 25% + bg 75%`     | Input borders, toggles              |
+| Variable          | Derivation            | Usage                    |
+| ----------------- | --------------------- | ------------------------ |
+| `--bg`            | Theme-defined         | Page background          |
+| `--text`          | Theme-defined         | Primary text             |
+| `--accent`        | Theme-defined         | Brand, links, selection  |
+| `--error`         | Theme-defined         | Error states             |
+| `--selection`     | `accent 55% + bg 45%` | Text selection highlight |
+| `--text-muted`    | `text 70% + bg 30%`   | Secondary text           |
+| `--surface-1`     | `bg 92% + text 8%`    | Card backgrounds         |
+| `--surface-2`     | `bg 86% + text 14%`   | Badge backgrounds        |
+| `--border`        | `text 15% + bg 85%`   | Standard borders         |
+| `--border-strong` | `text 25% + bg 75%`   | Input borders, toggles   |
 
 ### Theme Definitions
 
@@ -256,7 +255,7 @@ All colors are CSS custom properties, dynamically computed via `color-mix()`.
 
 ```
 Core (set by theme):     --bg, --text, --accent, --error
-Derived (auto-computed): --selection, --selection-active, --text-muted, --surface-1, --surface-2, --border, --border-strong
+Derived (auto-computed): --selection, --text-muted, --surface-1, --surface-2, --border, --border-strong
 ```
 
 ### When generating UI for this project

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,19 +14,19 @@ All colors are CSS custom properties, dynamically computed via `color-mix()`.
 
 ### Core Variables
 
-| Variable             | Derivation            | Usage                               |
-| -------------------- | --------------------- | ----------------------------------- |
-| `--bg`               | Theme-defined         | Page background                     |
-| `--text`             | Theme-defined         | Primary text                        |
-| `--accent`           | Theme-defined         | Brand, links, selection             |
-| `--error`            | Theme-defined         | Error states                        |
-| `--selection`        | `accent 35% + bg 65%` | Text selection highlight            |
-| `--selection-active` | `accent 50% + bg 50%` | Selection on active line (stronger) |
-| `--text-muted`       | `text 70% + bg 30%`   | Secondary text                      |
-| `--surface-1`        | `bg 92% + text 8%`    | Card backgrounds                    |
-| `--surface-2`        | `bg 86% + text 14%`   | Badge backgrounds                   |
-| `--border`           | `text 15% + bg 85%`   | Standard borders                    |
-| `--border-strong`    | `text 25% + bg 75%`   | Input borders, toggles              |
+| Variable             | Derivation              | Usage                               |
+| -------------------- | ----------------------- | ----------------------------------- |
+| `--bg`               | Theme-defined           | Page background                     |
+| `--text`             | Theme-defined           | Primary text                        |
+| `--accent`           | Theme-defined           | Brand, links, selection             |
+| `--error`            | Theme-defined           | Error states                        |
+| `--selection`        | `accent 35% + bg 65%`   | Text selection highlight            |
+| `--selection-active` | `accent 80% + text 20%` | Selection on active line (stronger) |
+| `--text-muted`       | `text 70% + bg 30%`     | Secondary text                      |
+| `--surface-1`        | `bg 92% + text 8%`      | Card backgrounds                    |
+| `--surface-2`        | `bg 86% + text 14%`     | Badge backgrounds                   |
+| `--border`           | `text 15% + bg 85%`     | Standard borders                    |
+| `--border-strong`    | `text 25% + bg 75%`     | Input borders, toggles              |
 
 ### Theme Definitions
 
@@ -35,7 +35,7 @@ All colors are CSS custom properties, dynamically computed via `color-mix()`.
 | default    | `#fdfdfc` | `#1f2933` | `#c7a443` | `#b42318` | Warm neutral    |
 | campus     | `#fdf8ec` | `#1f2937` | `#2f56c6` | `#b42318` | Academic blue   |
 | greenboard | `#102117` | `#e6f0e7` | `#96d46a` | `#ff9f9f` | Dark chalkboard |
-| whiteboard | `#e8e8e8` | `#1f2933` | `#3b82f6` | `#b42318` | Clean white     |
+| whiteboard | `#e8e8e8` | `#1f2933` | `#3b82f6` | `#b42318` | Clean gray      |
 | dotsD      | `#05080f` | `#e2ecff` | `#666666` | `#f472b6` | Dark modern     |
 | dotsF      | `#0000aa` | `#ffffff` | `#5ca8ff` | `#ff6666` | Retro neon      |
 
@@ -256,7 +256,7 @@ All colors are CSS custom properties, dynamically computed via `color-mix()`.
 
 ```
 Core (set by theme):     --bg, --text, --accent, --error
-Derived (auto-computed): --selection, --text-muted, --surface-1, --surface-2, --border, --border-strong
+Derived (auto-computed): --selection, --selection-active, --text-muted, --surface-1, --surface-2, --border, --border-strong
 ```
 
 ### When generating UI for this project

--- a/src/App.css
+++ b/src/App.css
@@ -17,6 +17,7 @@
 
   /* derived */
   --selection: color-mix(in srgb, var(--accent) 35%, var(--bg) 65%);
+  --selection-active: color-mix(in srgb, var(--accent) 50%, var(--bg) 50%);
   --text-muted: color-mix(in srgb, var(--text) 70%, var(--bg) 30%);
   --surface-1: color-mix(in srgb, var(--bg) 92%, var(--text) 8%);
   --surface-2: color-mix(in srgb, var(--bg) 86%, var(--text) 14%);
@@ -49,7 +50,7 @@
 }
 
 :root[data-theme='whiteboard'] {
-  --bg: #ffffff;
+  --bg: #e8e8e8;
   --text: #1f2933;
   --accent: #3b82f6;
   --error: #b42318;
@@ -65,6 +66,7 @@
   --error: #f472b6;
   --dirty-line: #888888;
   --selection: #3a3a3a;
+  --selection-active: #505050;
   --qr-filter: brightness(0) saturate(100%) invert(42%) sepia(0%) saturate(0%) hue-rotate(0deg)
     brightness(96%) contrast(89%);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -16,8 +16,7 @@
   --dirty-line: color-mix(in srgb, var(--accent) 80%, var(--text) 20%);
 
   /* derived */
-  --selection: color-mix(in srgb, var(--accent) 35%, var(--bg) 65%);
-  --selection-active: color-mix(in srgb, var(--accent) 80%, var(--text) 20%);
+  --selection: color-mix(in srgb, var(--accent) 55%, var(--bg) 45%);
   --text-muted: color-mix(in srgb, var(--text) 70%, var(--bg) 30%);
   --surface-1: color-mix(in srgb, var(--bg) 92%, var(--text) 8%);
   --surface-2: color-mix(in srgb, var(--bg) 86%, var(--text) 14%);
@@ -65,8 +64,7 @@
   --accent: #666666;
   --error: #f472b6;
   --dirty-line: #888888;
-  --selection: #3a3a3a;
-  --selection-active: #707070;
+  --selection: #555555;
   --qr-filter: brightness(0) saturate(100%) invert(42%) sepia(0%) saturate(0%) hue-rotate(0deg)
     brightness(96%) contrast(89%);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -17,7 +17,7 @@
 
   /* derived */
   --selection: color-mix(in srgb, var(--accent) 35%, var(--bg) 65%);
-  --selection-active: color-mix(in srgb, var(--accent) 50%, var(--bg) 50%);
+  --selection-active: color-mix(in srgb, var(--accent) 80%, var(--text) 20%);
   --text-muted: color-mix(in srgb, var(--text) 70%, var(--bg) 30%);
   --surface-1: color-mix(in srgb, var(--bg) 92%, var(--text) 8%);
   --surface-2: color-mix(in srgb, var(--bg) 86%, var(--text) 14%);
@@ -66,7 +66,7 @@
   --error: #f472b6;
   --dirty-line: #888888;
   --selection: #3a3a3a;
-  --selection-active: #505050;
+  --selection-active: #707070;
   --qr-filter: brightness(0) saturate(100%) invert(42%) sepia(0%) saturate(0%) hue-rotate(0deg)
     brightness(96%) contrast(89%);
 }

--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -226,6 +226,10 @@
       '.cm-cursor, .cm-dropCursor': {
         borderLeftColor: 'var(--accent)',
       },
+      '.cm-fat-cursor, &:not(.cm-focused) .cm-fat-cursor': {
+        background: 'var(--accent) !important',
+        outline: 'none !important',
+      },
       '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
         backgroundColor: 'var(--selection) !important',
         color: 'var(--text)',
@@ -276,14 +280,12 @@
         '.cm-cursor, .cm-dropCursor': {
           borderLeftColor: 'var(--accent)',
         },
+        '.cm-fat-cursor, &:not(.cm-focused) .cm-fat-cursor': {
+          background: 'var(--accent) !important',
+          outline: 'none !important',
+        },
         '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
           backgroundColor: 'var(--selection) !important',
-          color: 'var(--text)',
-          mixBlendMode: 'normal',
-          opacity: 1,
-        },
-        '.cm-activeLine .cm-selectionBackground': {
-          backgroundColor: 'var(--selection-active) !important',
           color: 'var(--text)',
           mixBlendMode: 'normal',
           opacity: 1,

--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -232,14 +232,8 @@
         mixBlendMode: 'normal',
         opacity: 1,
       },
-      '.cm-activeLine .cm-selectionBackground': {
-        backgroundColor: 'var(--selection-active) !important',
-        color: 'var(--text)',
-        mixBlendMode: 'normal',
-        opacity: 1,
-      },
       '.cm-activeLine': {
-        backgroundColor: 'color-mix(in srgb, var(--surface-1) 60%, transparent 40%)',
+        backgroundColor: 'color-mix(in srgb, var(--surface-1) 35%, transparent 65%)',
       },
       '.cm-gutters': {
         backgroundColor: 'var(--bg)',
@@ -259,7 +253,7 @@
         color: 'var(--text-muted)',
       },
       '.cm-activeLineGutter': {
-        backgroundColor: 'color-mix(in srgb, var(--surface-1) 60%, transparent 40%)',
+        backgroundColor: 'color-mix(in srgb, var(--surface-1) 35%, transparent 65%)',
       },
     })
   }
@@ -295,7 +289,7 @@
           opacity: 1,
         },
         '.cm-activeLine': {
-          backgroundColor: 'color-mix(in srgb, var(--surface-1) 60%, transparent 40%)',
+          backgroundColor: 'color-mix(in srgb, var(--surface-1) 35%, transparent 65%)',
         },
         '.cm-gutters': {
           backgroundColor: 'var(--bg)',
@@ -315,7 +309,7 @@
           color: 'var(--text-muted)',
         },
         '.cm-activeLineGutter': {
-          backgroundColor: 'color-mix(in srgb, var(--surface-1) 60%, transparent 40%)',
+          backgroundColor: 'color-mix(in srgb, var(--surface-1) 35%, transparent 65%)',
         },
       },
       { dark: true }
@@ -338,7 +332,7 @@
           padding: '6px 0',
         },
         '.cm-activeLineGutter': {
-          backgroundColor: 'color-mix(in srgb, var(--surface-1) 60%, transparent 40%)',
+          backgroundColor: 'color-mix(in srgb, var(--surface-1) 35%, transparent 65%)',
         },
       },
       isDark ? { dark: true } : {}

--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -233,7 +233,7 @@
         opacity: 1,
       },
       '.cm-activeLine .cm-selectionBackground': {
-        backgroundColor: 'var(--selection) !important',
+        backgroundColor: 'var(--selection-active) !important',
         color: 'var(--text)',
         mixBlendMode: 'normal',
         opacity: 1,
@@ -289,7 +289,7 @@
           opacity: 1,
         },
         '.cm-activeLine .cm-selectionBackground': {
-          backgroundColor: 'var(--selection) !important',
+          backgroundColor: 'var(--selection-active) !important',
           color: 'var(--text)',
           mixBlendMode: 'normal',
           opacity: 1,


### PR DESCRIPTION
## 関連 Issue
closes #94

## 変更内容

### 問題1: 現在行での範囲選択が見えない
- `--selection-active` CSS変数を追加（accent比率50%、通常selectionの35%より強い）
- dotsD用に `--selection-active: #505050` をオーバーライド（通常の `#3a3a3a` より明るい）
- CodeMirrorの `.cm-activeLine .cm-selectionBackground` で `--selection-active` を使用

### 問題2: ホワイトボードの個性不足
- whiteboard の `--bg` を `#ffffff` → `#e8e8e8` に変更（現実のホワイトボードのような薄グレー）
- yomi (`#fdfdfc`) との差別化を明確に

### ドキュメント
- DESIGN.md の Core Variables テーブルに `--selection-active` を追加
- Theme Definitions テーブルの whiteboard `--bg` を更新