### PR TITLE
fix: スクロール後にカーソルトレイルが壊れる問題を修正

### DIFF
--- a/docs/development/ui/cursor-trail.md
+++ b/docs/development/ui/cursor-trail.md
@@ -29,13 +29,16 @@
 
 CodeMirrorの `EditorView.updateListener` を使い、以下のイベントを監視:
 
-- **初回描画時**: `.cm-scroller` 内にcanvasを生成し、WebGL2コンテキストを初期化
+- **初回描画時**: `.cm-scroller` 内にcanvasを生成し、WebGL2コンテキストを初期化。同時に `scrollDOM` の `scroll` イベントリスナーを登録
 - **selectionSet / docChanged**: カーソル座標を更新し、アニメーションループを再開
 - **geometryChanged**: canvasをリサイズ
+- **scroll（DOM イベント）**: スクロール時にカーソル座標を再取得し、前回座標=現在座標にリセットして軌跡を切る
 
 ### 座標計算
 
 `view.coordsAtPos()` でカーソルのビューポート座標を取得し、`.cm-scroller` のBoundingClientRectとの差分でscroller内相対座標に変換。devicePixelRatioを考慮してシェーダーに渡す。
+
+`coordsAtPos()` はカーソルがビューポート外の場合 `null` を返す。この場合は座標更新をスキップし、前回座標をリセットすることで、スクロール復帰時に古い位置からの不正な軌跡が描画されることを防ぐ。
 
 ### カーソル形状検出
 

--- a/src/lib/editor/cursor-trail.ts
+++ b/src/lib/editor/cursor-trail.ts
@@ -189,6 +189,10 @@ export function createCursorTrailExtension(modules: {
   let isFirstUpdate = true
   let accentColorRGB: [number, number, number] = [0.4, 0.6, 1.0]
 
+  // スクロール監視
+  let scrollHandler: (() => void) | null = null
+  let scrollView: InstanceType<typeof EditorView> | null = null
+
   // reduced-motion の動的変更を監視
   let motionQuery: MediaQueryList | null = null
   let motionListener: ((e: MediaQueryListEvent) => void) | null = null
@@ -329,10 +333,20 @@ export function createCursorTrailExtension(modules: {
     animFrameId = requestAnimationFrame(frame)
   }
 
+  function resetTrailToCurrent() {
+    previousCursorX = currentCursorX
+    previousCursorY = currentCursorY
+  }
+
   function updateCursorPosition(view: InstanceType<typeof EditorView>) {
     const sel = view.state.selection.main
     const coords = view.coordsAtPos(sel.head)
-    if (!coords) return
+
+    // カーソルがビューポート外: 座標を取得できないので軌跡をリセット
+    if (!coords) {
+      resetTrailToCurrent()
+      return
+    }
 
     const scroller = view.scrollDOM
     if (!scroller) return
@@ -361,8 +375,7 @@ export function createCursorTrailExtension(modules: {
 
     // 初回は前の位置も同じにする（トレイルが画面端から出ないように）
     if (isFirstUpdate) {
-      previousCursorX = currentCursorX
-      previousCursorY = currentCursorY
+      resetTrailToCurrent()
       isFirstUpdate = false
     }
 
@@ -372,11 +385,39 @@ export function createCursorTrailExtension(modules: {
     startLoop()
   }
 
+  function onScroll(view: InstanceType<typeof EditorView>) {
+    const sel = view.state.selection.main
+    const coords = view.coordsAtPos(sel.head)
+
+    if (!coords) {
+      // カーソルがビューポート外: 軌跡をリセットするだけ
+      resetTrailToCurrent()
+      return
+    }
+
+    const scroller = view.scrollDOM
+    if (!scroller) return
+    const scrollerRect = scroller.getBoundingClientRect()
+
+    const x = coords.left - scrollerRect.left
+    const y = coords.top - scrollerRect.top
+
+    // スクロール後の座標で両方を更新（軌跡を切る）
+    currentCursorX = x
+    currentCursorY = y
+    resetTrailToCurrent()
+  }
+
   // ViewPlugin 定義
   const cursorTrailPlugin = EditorView.updateListener.of((update) => {
-    // エディタ初期化時に canvas をセットアップ
+    // エディタ初期化時に canvas をセットアップ + スクロール監視を登録
     if (!canvas) {
       setupCanvas(update.view.dom)
+      if (!scrollHandler) {
+        scrollView = update.view
+        scrollHandler = () => onScroll(scrollView!)
+        update.view.scrollDOM.addEventListener('scroll', scrollHandler, { passive: true })
+      }
     }
 
     // カーソル位置の変更を検知
@@ -405,6 +446,11 @@ export function createCursorTrailExtension(modules: {
   function cleanupInternal() {
     destroyed = true
     stopLoop()
+    if (scrollHandler && scrollView) {
+      scrollView.scrollDOM.removeEventListener('scroll', scrollHandler)
+      scrollHandler = null
+      scrollView = null
+    }
     if (gl) {
       if (buf) {
         gl.deleteBuffer(buf)

--- a/src/lib/editor/cursor-trail.ts
+++ b/src/lib/editor/cursor-trail.ts
@@ -338,23 +338,32 @@ export function createCursorTrailExtension(modules: {
     previousCursorY = currentCursorY
   }
 
-  function updateCursorPosition(view: InstanceType<typeof EditorView>) {
+  /** カーソルの scroller 内相対座標を返す。ビューポート外なら null */
+  function getCursorScrollerCoords(
+    view: InstanceType<typeof EditorView>
+  ): { x: number; y: number } | null {
     const sel = view.state.selection.main
     const coords = view.coordsAtPos(sel.head)
+    if (!coords) return null
+
+    const scroller = view.scrollDOM
+    if (!scroller) return null
+    const scrollerRect = scroller.getBoundingClientRect()
+
+    return {
+      x: coords.left - scrollerRect.left,
+      y: coords.top - scrollerRect.top,
+    }
+  }
+
+  function updateCursorPosition(view: InstanceType<typeof EditorView>) {
+    const pos = getCursorScrollerCoords(view)
 
     // カーソルがビューポート外: 座標を取得できないので軌跡をリセット
-    if (!coords) {
+    if (!pos) {
       resetTrailToCurrent()
       return
     }
-
-    const scroller = view.scrollDOM
-    if (!scroller) return
-    const scrollerRect = scroller.getBoundingClientRect()
-
-    // スクロール位置を考慮した相対座標
-    const x = coords.left - scrollerRect.left
-    const y = coords.top - scrollerRect.top
 
     // カーソル形状検出
     const editorEl = view.dom
@@ -370,8 +379,8 @@ export function createCursorTrailExtension(modules: {
     previousCursorY = currentCursorY
 
     // 新しい位置を設定
-    currentCursorX = x
-    currentCursorY = y
+    currentCursorX = pos.x
+    currentCursorY = pos.y
 
     // 初回は前の位置も同じにする（トレイルが画面端から出ないように）
     if (isFirstUpdate) {
@@ -385,39 +394,32 @@ export function createCursorTrailExtension(modules: {
     startLoop()
   }
 
+  /** スクロール時: 座標を再取得して軌跡を切る（startLoop は呼ばない） */
   function onScroll(view: InstanceType<typeof EditorView>) {
-    const sel = view.state.selection.main
-    const coords = view.coordsAtPos(sel.head)
+    const pos = getCursorScrollerCoords(view)
 
-    if (!coords) {
-      // カーソルがビューポート外: 軌跡をリセットするだけ
+    if (!pos) {
       resetTrailToCurrent()
       return
     }
 
-    const scroller = view.scrollDOM
-    if (!scroller) return
-    const scrollerRect = scroller.getBoundingClientRect()
-
-    const x = coords.left - scrollerRect.left
-    const y = coords.top - scrollerRect.top
-
-    // スクロール後の座標で両方を更新（軌跡を切る）
-    currentCursorX = x
-    currentCursorY = y
+    currentCursorX = pos.x
+    currentCursorY = pos.y
     resetTrailToCurrent()
   }
 
   // ViewPlugin 定義
   const cursorTrailPlugin = EditorView.updateListener.of((update) => {
-    // エディタ初期化時に canvas をセットアップ + スクロール監視を登録
+    // エディタ初期化時に canvas をセットアップ
     if (!canvas) {
       setupCanvas(update.view.dom)
-      if (!scrollHandler) {
-        scrollView = update.view
-        scrollHandler = () => onScroll(scrollView!)
-        update.view.scrollDOM.addEventListener('scroll', scrollHandler, { passive: true })
-      }
+    }
+
+    // canvas が正常に作成された場合のみスクロール監視を登録
+    if (canvas && !scrollHandler) {
+      scrollView = update.view
+      scrollHandler = () => onScroll(scrollView!)
+      update.view.scrollDOM.addEventListener('scroll', scrollHandler, { passive: true })
     }
 
     // カーソル位置の変更を検知


### PR DESCRIPTION
## 関連 Issue
closes #104

## 変更内容
- `coordsAtPos()` が `null`（カーソルがビューポート外）のとき、前回座標をリセットして軌跡が古い位置から飛んでくるのを防止
- `scrollDOM` の `scroll` イベントを監視し、スクロール時に座標を再取得して前回座標=現在座標にリセット（軌跡を切る）
- クリーンアップ時にスクロールリスナーを解除
- 開発ドキュメントにスクロール対応の記述を追記

## 変更ファイル
- `src/lib/editor/cursor-trail.ts` — バグ修正本体
- `docs/development/ui/cursor-trail.md` — ドキュメント更新