### PR TITLE
feat: Pull時のblob SHAキャッシュによる���分取得

### DIFF
--- a/docs/development/storage.md
+++ b/docs/development/storage.md
@@ -89,14 +89,15 @@ Agasteerのデータ永続化スキーマについて説明します。
 
 #### `leaves` オブジェクトストア
 
-| フィールド | 型     | 説明                                |
-| ---------- | ------ | ----------------------------------- |
-| id         | string | UUID（主キー）                      |
-| title      | string | リーフタイトル                      |
-| noteId     | string | 所属ノートのID                      |
-| content    | string | Markdownコンテンツ                  |
-| updatedAt  | number | 最終更新タイムスタンプ（Unix time） |
-| order      | number | 並び順                              |
+| フィールド | 型      | 説明                                                         |
+| ---------- | ------- | ------------------------------------------------------------ |
+| id         | string  | UUID（主キー）                                               |
+| title      | string  | リーフタイトル                                               |
+| noteId     | string  | 所属ノートのID                                               |
+| content    | string  | Markdownコンテンツ                                           |
+| updatedAt  | number  | 最終更新タイムスタンプ（Unix time）                          |
+| order      | number  | 並び順                                                       |
+| blobSha    | string? | Git blob SHA（Pull時にTree APIから取得。差分Pull判定に使用） |
 
 **例:**
 
@@ -108,7 +109,8 @@ Agasteerのデータ永続化スキーマについて説明します。
     "noteId": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
     "content": "# 会議メモ\n\n## 議題\n- ...",
     "updatedAt": 1703000000000,
-    "order": 0
+    "order": 0,
+    "blobSha": "a1b2c3d4e5f6..."
   }
 ]
 ```

--- a/docs/development/sync/github-api.md
+++ b/docs/development/sync/github-api.md
@@ -302,11 +302,44 @@ Pull/Push操作の排他制御を一元管理する関数。Pull中またはPush
 
 この段階的制御により、残りのリーフ取得中にユーザーが同名リーフを作成したり、まだ取得していないノートを削除するなどの矛盾を防ぎます。
 
+### blob SHAキャッシュによる差分Pull（2026-04）
+
+変更のないリーフのcontent取得をスキップし、API呼び出し回数を削減する。
+
+**仕組み:**
+
+1. Pull成功時、Tree APIから取得した各リーフのblob SHAをIndexedDBにリーフと一緒に保存（`blobSha`フィールド）
+2. 次回Pull時、Tree APIのSHAとIndexedDBの保存SHAを比較
+3. 一致すればcontent取得をスキップし、IndexedDBの既存contentをそのまま使用
+4. 不一致または保存SHAなし → 従来どおりfetch
+
+**フォールバック:**
+
+- IndexedDBが空（初回起動、クリア後）→ 全件fetch（従来動作）
+- IndexedDBのリーフに`blobSha`フィールドがない（移行期）→ 不一致扱いでfetch
+- SHAが一致してもcontentが空 → fetch
+
+**GH上で直接編集された場合:**
+
+blob SHAが変わるため、次回Pull時にTree APIが新しいSHAを返し、不一致 → 正しくfetchされる。
+
+**設計原則との整合:**
+
+- GitHubがSSoT（Single Source of Truth）である原則を維持
+- リモートのSHAを正として判断し、ローカルはキャッシュとして扱う
+- ローカルのcontentからSHA再計算は不要（Tree APIのSHAをそのまま保存・比較）
+
+**効果:**
+
+- 100件中5件変更: 102回 → 7回のAPI呼び出し（96%削減）
+- アーカイブ300件（ほぼ変更なし）: 302回 → 2回
+
 ### 技術的な最適化
 
 - **生テキスト取得**: `Accept: application/vnd.github.raw`でBase64デコードを回避
 - **並列取得**: `CONTENT_FETCH_CONCURRENCY = 10`で10並列実行
 - **キャッシュバスター**: `?t=${Date.now()}`で常に最新データを取得
+- **blob SHAキャッシュ**: IndexedDBの保存SHAとTree APIのSHAが一致すればfetchスキップ
 
 ### Base64デコード
 

--- a/src/lib/actions/git.ts
+++ b/src/lib/actions/git.ts
@@ -278,6 +278,14 @@ export async function pullFromGitHub(
       )
     }
 
+    // blob SHAキャッシュ用: クリア前にバックアップのリーフからSHA→Leafのマップを構築
+    const cachedLeafMap = new Map<string, Leaf>()
+    for (const leaf of backup.leaves) {
+      if (leaf.blobSha) {
+        cachedLeafMap.set(leaf.blobSha, leaf)
+      }
+    }
+
     // 重要: GitHubが唯一の真実の情報源（Single Source of Truth）
     await clearAllData()
     notes.value = []
@@ -290,6 +298,7 @@ export async function pullFromGitHub(
     rightLeaf.value = null
 
     const options: PullOptions = {
+      cachedLeaves: cachedLeafMap.size > 0 ? cachedLeafMap : undefined,
       // ノート構造確定時
       onStructure: (notesFromGitHub, metadataFromGitHub, leafSkeletons) => {
         notes.value = notesFromGitHub

--- a/src/lib/actions/git.ts
+++ b/src/lib/actions/git.ts
@@ -1,4 +1,4 @@
-import type { Note, Leaf } from '../types'
+import { type Note, type Leaf, buildBlobShaCache } from '../types'
 import type { PullOptions } from '../api'
 import { showPushToast, showPullToast, confirmAsync, choiceAsync } from '../ui'
 import {
@@ -279,12 +279,7 @@ export async function pullFromGitHub(
     }
 
     // blob SHAキャッシュ用: クリア前にバックアップのリーフからSHA→Leafのマップを構築
-    const cachedLeafMap = new Map<string, Leaf>()
-    for (const leaf of backup.leaves) {
-      if (leaf.blobSha) {
-        cachedLeafMap.set(leaf.blobSha, leaf)
-      }
-    }
+    const cachedLeafMap = buildBlobShaCache(backup.leaves)
 
     // 重要: GitHubが唯一の真実の情報源（Single Source of Truth）
     await clearAllData()

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -182,6 +182,8 @@ export interface PullOptions {
   onLeaf?: (leaf: Leaf) => void
   /** 第1優先リーフ全取得完了時のコールバック */
   onPriorityComplete?: () => void
+  /** blob SHAキャッシュ: SHAをキーにしたLeafのMap（一致すればfetchスキップ） */
+  cachedLeaves?: Map<string, Leaf>
 }
 
 // コンテンツ取得を並列化する際の上限（HTTP/2では同時接続数制限が緩和されている）
@@ -1444,6 +1446,31 @@ export async function pullFromGitHub(
       sortedTargets,
       CONTENT_FETCH_CONCURRENCY,
       async (target) => {
+        // blob SHAキャッシュ: IndexedDBのSHAと一致すればfetchスキップ
+        const cached = options?.cachedLeaves?.get(target.entry.sha)
+        if (cached?.content) {
+          const leaf: Leaf = {
+            id: target.leafMeta.id,
+            title: target.title,
+            noteId: target.noteId,
+            content: cached.content,
+            updatedAt: target.leafMeta.updatedAt,
+            order: target.leafMeta.order,
+            badgeIcon: target.leafMeta.badgeIcon,
+            badgeColor: target.leafMeta.badgeColor,
+            blobSha: target.entry.sha,
+          }
+          options?.onLeaf?.(leaf)
+          if (getPriority(target) === 0) {
+            priority1Completed++
+            if (priority1Completed >= priority1Count && !priority1CallbackFired) {
+              priority1CallbackFired = true
+              options?.onPriorityComplete?.()
+            }
+          }
+          return leaf
+        }
+
         const contentRes = await fetchGitHubContents(
           target.entry.path,
           settings.repoName,
@@ -1469,6 +1496,7 @@ export async function pullFromGitHub(
           order: target.leafMeta.order,
           badgeIcon: target.leafMeta.badgeIcon,
           badgeColor: target.leafMeta.badgeColor,
+          blobSha: target.entry.sha,
         }
 
         // 各リーフ取得完了時のコールバック
@@ -1760,6 +1788,8 @@ export interface ArchivePullResult {
 export interface ArchivePullOptions {
   /** 進捗報告コールバック: リーフ取得完了時に呼び出し（統計更新用） */
   onLeafFetched?: (leaf: Leaf) => void
+  /** blob SHAキャッシュ: SHAをキーにしたLeafのMap（一致すればfetchスキップ） */
+  cachedLeaves?: Map<string, Leaf>
 }
 
 /**
@@ -2026,6 +2056,24 @@ export async function pullArchive(
       leafTargets,
       CONTENT_FETCH_CONCURRENCY,
       async (target) => {
+        // blob SHAキャッシュ: IndexedDBのSHAと一致すればfetchスキップ
+        const cached = options.cachedLeaves?.get(target.entry.sha)
+        if (cached?.content) {
+          const leaf: Leaf = {
+            id: target.leafMeta.id,
+            title: target.title,
+            noteId: target.noteId,
+            content: cached.content,
+            updatedAt: target.leafMeta.updatedAt,
+            order: target.leafMeta.order,
+            badgeIcon: target.leafMeta.badgeIcon,
+            badgeColor: target.leafMeta.badgeColor,
+            blobSha: target.entry.sha,
+          }
+          options.onLeafFetched?.(leaf)
+          return leaf
+        }
+
         const contentRes = await fetchGitHubContents(
           target.entry.path,
           settings.repoName,
@@ -2051,6 +2099,7 @@ export async function pullArchive(
           order: target.leafMeta.order,
           badgeIcon: target.leafMeta.badgeIcon,
           badgeColor: target.leafMeta.badgeColor,
+          blobSha: target.entry.sha,
         }
 
         // 進捗報告

--- a/src/lib/pane-navigation.svelte.ts
+++ b/src/lib/pane-navigation.svelte.ts
@@ -7,7 +7,14 @@
 
 import { tick } from 'svelte'
 import { get } from 'svelte/store'
-import type { Note, Leaf, Breadcrumb, WorldType, SearchMatch } from './types'
+import {
+  type Note,
+  type Leaf,
+  type Breadcrumb,
+  type WorldType,
+  type SearchMatch,
+  buildBlobShaCache,
+} from './types'
 import type { Pane } from './navigation'
 import * as nav from './navigation'
 import { resolvePath, buildPath, extractWorldPrefix } from './navigation'
@@ -261,19 +268,6 @@ export function handleDisabledPushClick(reason: string, pushDisabledReason: stri
 // ========================================
 // Archive cache helper
 // ========================================
-
-/**
- * リーフ配列からblob SHA→Leafのマップを構築（Pull時のキャッシュ比較用）
- */
-function buildBlobShaCache(leafList: Leaf[]): Map<string, Leaf> {
-  const map = new Map<string, Leaf>()
-  for (const leaf of leafList) {
-    if (leaf.blobSha) {
-      map.set(leaf.blobSha, leaf)
-    }
-  }
-  return map
-}
 
 /**
  * IndexedDBからアーカイブキャッシュを読み込み、ストアにセットする。
@@ -737,11 +731,11 @@ export async function restoreStateFromUrl(alreadyRestoring = false) {
       archiveLeafStatsStore.reset()
     }
     // blob SHAキャッシュ用: キャッシュ済みリーフからSHA→Leafのマップを構築
-    const cachedLeafMap2 = buildBlobShaCache(archiveLeaves.value)
+    const cachedLeafMap = buildBlobShaCache(archiveLeaves.value)
     try {
       const result = await pullArchive(settings.value, {
         onLeafFetched: (leaf) => archiveLeafStatsStore.addLeaf(leaf.id, leaf.content),
-        cachedLeaves: cachedLeafMap2.size > 0 ? cachedLeafMap2 : undefined,
+        cachedLeaves: cachedLeafMap.size > 0 ? cachedLeafMap : undefined,
       })
       if (result.success) {
         archiveNotes.value = result.notes

--- a/src/lib/pane-navigation.svelte.ts
+++ b/src/lib/pane-navigation.svelte.ts
@@ -263,6 +263,19 @@ export function handleDisabledPushClick(reason: string, pushDisabledReason: stri
 // ========================================
 
 /**
+ * リーフ配列からblob SHA→Leafのマップを構築（Pull時のキャッシュ比較用）
+ */
+function buildBlobShaCache(leafList: Leaf[]): Map<string, Leaf> {
+  const map = new Map<string, Leaf>()
+  for (const leaf of leafList) {
+    if (leaf.blobSha) {
+      map.set(leaf.blobSha, leaf)
+    }
+  }
+  return map
+}
+
+/**
  * IndexedDBからアーカイブキャッシュを読み込み、ストアにセットする。
  * @returns キャッシュが存在したかどうか
  */
@@ -308,9 +321,12 @@ export async function handleWorldChange(world: WorldType, pane: Pane = 'left') {
       if (!hasCachedData) {
         archiveLeafStatsStore.reset()
       }
+      // blob SHAキャッシュ用: キャッシュ済みリーフからSHA→Leafのマップを構築
+      const cachedLeafMap = buildBlobShaCache(archiveLeaves.value)
       try {
         const result = await pullArchive(settings.value, {
           onLeafFetched: (leaf) => archiveLeafStatsStore.addLeaf(leaf.id, leaf.content),
+          cachedLeaves: cachedLeafMap.size > 0 ? cachedLeafMap : undefined,
         })
         if (result.success) {
           archiveNotes.value = result.notes
@@ -720,9 +736,12 @@ export async function restoreStateFromUrl(alreadyRestoring = false) {
     if (!hasCachedData) {
       archiveLeafStatsStore.reset()
     }
+    // blob SHAキャッシュ用: キャッシュ済みリーフからSHA→Leafのマップを構築
+    const cachedLeafMap2 = buildBlobShaCache(archiveLeaves.value)
     try {
       const result = await pullArchive(settings.value, {
         onLeafFetched: (leaf) => archiveLeafStatsStore.addLeaf(leaf.id, leaf.content),
+        cachedLeaves: cachedLeafMap2.size > 0 ? cachedLeafMap2 : undefined,
       })
       if (result.success) {
         archiveNotes.value = result.notes

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,6 +71,7 @@ export interface Leaf {
   order: number
   badgeIcon?: string
   badgeColor?: string
+  blobSha?: string
 }
 
 export interface BreadcrumbSibling {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,6 +74,19 @@ export interface Leaf {
   blobSha?: string
 }
 
+/**
+ * リーフ配列からblob SHA→Leafのマップを構築（Pull時のキャッシュ比較用）
+ */
+export function buildBlobShaCache(leafList: Leaf[]): Map<string, Leaf> {
+  const map = new Map<string, Leaf>()
+  for (const leaf of leafList) {
+    if (leaf.blobSha) {
+      map.set(leaf.blobSha, leaf)
+    }
+  }
+  return map
+}
+
 export interface BreadcrumbSibling {
   id: UUID
   label: string


### PR DESCRIPTION
## 関連 Issue
closes #106

## 変更内容
- Pull時、Tree APIから取得したblob SHAをIndexedDBにリーフと一緒に保存
- 次回Pull時、SHAが一致するリーフはcontent fetchをスキップしIndexedDBのキャッシュを使用
- Home Pull / Archive Pull の両方に適用
- blobShaがundefinedなら自然に不一致扱いでfetch（移行コード不要）

## 期待される効果
- 100件中5件変更: 102回 → 7回のAPI呼び出し（96%削減）
- アーカイブ300件（ほぼ変更なし）: 302回 → 2回