### PR TITLE
feat: #108 Priority リーフを Pull 完了前から常時表示する

### DIFF
--- a/src/components/layout/PaneView.svelte
+++ b/src/components/layout/PaneView.svelte
@@ -168,7 +168,6 @@
       notes={activeRootNotes}
       allLeaves={activeLeaves}
       isFirstPriorityFetched={isArchiveWorld || paneState.value.isFirstPriorityFetched}
-      isPullCompleted={isArchiveWorld || paneState.value.isPullCompleted}
       {selectedIndex}
       {isActive}
       vimMode={settings.value.vimMode ?? false}

--- a/src/components/views/HomeView.svelte
+++ b/src/components/views/HomeView.svelte
@@ -16,7 +16,6 @@
     onDrop: (note: Note) => void
     dragOverNoteId?: string | null
     isFirstPriorityFetched?: boolean
-    isPullCompleted?: boolean
     selectedIndex?: number
     isActive?: boolean
     vimMode?: boolean
@@ -40,7 +39,6 @@
     onDrop,
     dragOverNoteId = null,
     isFirstPriorityFetched = false,
-    isPullCompleted = false,
     selectedIndex = 0,
     isActive = true,
     vimMode = false,
@@ -84,7 +82,7 @@
 
   // 特殊リーフ（Offline, Priority）のカウント（Vimナビゲーション用）
   // Priorityは全リーフPull完了後のみ表示されるのでカウントに含める
-  let specialLeafCount = $derived((offlineLeaf ? 1 : 0) + (priorityLeaf && isPullCompleted ? 1 : 0))
+  let specialLeafCount = $derived((offlineLeaf ? 1 : 0) + (priorityLeaf ? 1 : 0))
 
   // Vimモードで選択が変わったら選択中のカードが見えるようにスクロール
   $effect(() => {
@@ -192,8 +190,8 @@
       </div>
     {/if}
 
-    <!-- Priority リーフ: Offlineの次に表示（全リーフPull完了後のみ） -->
-    {#if priorityLeaf && isPullCompleted}
+    <!-- Priority リーフ: Offlineの次に常に表示（Pull中は内容がリアルタイムに更新される） -->
+    {#if priorityLeaf}
       <div
         class="leaf-card"
         class:selected={vimMode && isActive && selectedIndex === (offlineLeaf ? 1 : 0)}

--- a/src/lib/keyboard-nav.svelte.ts
+++ b/src/lib/keyboard-nav.svelte.ts
@@ -43,8 +43,7 @@ export function getCurrentItemsForPane(pane: Pane): (Note | Leaf)[] {
     const specialLeaves: Leaf[] = []
     if (getWorldForPane(pane) !== 'archive') {
       if (derivedState.currentOfflineLeaf) specialLeaves.push(derivedState.currentOfflineLeaf)
-      if (derivedState.currentPriorityLeaf && appState.isPullCompleted)
-        specialLeaves.push(derivedState.currentPriorityLeaf)
+      if (derivedState.currentPriorityLeaf) specialLeaves.push(derivedState.currentPriorityLeaf)
     }
     const rootNotes = paneNotes.filter((n) => !n.parentId).sort((a, b) => a.order - b.order)
     return [...specialLeaves, ...rootNotes]


### PR DESCRIPTION
## 関連 Issue
closes #108

## 変更内容
Priority リーフの表示条件から `isPullCompleted` を除去し、Offline リーフと同様に常時表示にする。

`priorityItems` は `leaves.value` のリアクティブな `$derived` なので、Pull 中にリーフが届くたびに Priority の内容もリアルタイムに更新される。スケルトンやプレースホルダーは不要。

- `HomeView.svelte`: `isPullCompleted` 条件と未使用 prop を削除
- `keyboard-nav.svelte.ts`: Vim ナビの Priority 条件から `isPullCompleted` を除去
- `PaneView.svelte`: HomeView への `isPullCompleted` 渡しを削除
- `specialLeafCount` を常に Offline + Priority で計算（位置ずれ解消）