### PR TITLE
fix: #109 初回Pull失敗時に古いリーフをリストアしない

### DIFF
--- a/src/lib/actions/git.ts
+++ b/src/lib/actions/git.ts
@@ -378,7 +378,8 @@ export async function pullFromGitHub(
         appState.isFirstPriorityFetched = false
         notes.value = []
         leaves.value = []
-      } else if (hasBackupData) {
+      } else if (hasBackupData && !isInitialStartup) {
+        // 非初回Pull失敗: 直前の同期済みデータにリストアする（作業中の状態を保護）
         console.log('Pull failed, restoring from backup...')
         try {
           await restoreFromBackup(backup)
@@ -391,6 +392,8 @@ export async function pullFromGitHub(
           console.error('Failed to restore from backup:', restoreError)
         }
       }
+      // 初回Pull失敗: リストアしない。UIはロック状態（ガラス状）を維持。
+      // Offlineリーフのみ操作可能。オンライン復帰で自動リトライする。
     }
 
     const translatedMessage = translateGitHubMessage(

--- a/src/lib/app-state.svelte.ts
+++ b/src/lib/app-state.svelte.ts
@@ -901,6 +901,16 @@ export function initApp(deps: InitAppDeps): () => void {
   }
   document.addEventListener('visibilitychange', handleVisibilityChange)
 
+  // オンライン復帰時の自動Pull リトライ
+  // 初回Pull失敗（オフライン起動）後、ネットワーク復帰で自動的にPullを再試行する
+  const handleOnline = () => {
+    if (!appState.isFirstPriorityFetched && !isPulling.value) {
+      console.log('Online detected: retrying initial pull')
+      deps.pullFromGitHub(true)
+    }
+  }
+  window.addEventListener('online', handleOnline)
+
   // 自動Push機能（$effect.rootで購読）
   const cleanupAutoPush = $effect.root(() => {
     $effect(() => {
@@ -1019,6 +1029,7 @@ export function initApp(deps: InitAppDeps): () => void {
     window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
     window.removeEventListener('appinstalled', handleAppInstalled)
     document.removeEventListener('visibilitychange', handleVisibilityChange)
+    window.removeEventListener('online', handleOnline)
     cleanupAutoPush()
     cleanupAutoPull()
     cleanupStoreEffects()


### PR DESCRIPTION
## 関連 Issue
closes #109

## 変更内容
オフライン起動時の初回 Pull 失敗で、前回セッションの古いリーフがリストア＆編集可能になるバグを修正。

### git.ts
- `isInitialStartup` が true の場合、Pull 失敗時のバックアップリストアをスキップ
- UI はガラス状（ロック状態 = `isFirstPriorityFetched: false`）を維持
- Offline リーフのみ操作可能
- 非初回 Pull 失敗時のリストアは従来通り（作業中データの保護）

### app-state.svelte.ts
- `online` イベントリスナーを追加
- 初回 Pull 未完了 (`!isFirstPriorityFetched`) かつ Pull 中でなければ自動リトライ
- cleanup で適切にリスナーを解除