### PR TITLE
fix: #112 エディタ本文の色消失を防止（バックグラウンド復帰後）

### DIFF
--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -222,6 +222,7 @@
       },
       '.cm-content': {
         caretColor: 'var(--accent)',
+        color: 'var(--text)',
       },
       '.cm-cursor, .cm-dropCursor': {
         borderLeftColor: 'var(--accent)',
@@ -276,6 +277,7 @@
         },
         '.cm-content': {
           caretColor: 'var(--accent)',
+          color: 'var(--text)',
         },
         '.cm-cursor, .cm-dropCursor': {
           borderLeftColor: 'var(--accent)',


### PR DESCRIPTION
## 関連 Issue
closes #112

## 変更内容
`.cm-content` に `color: var(--text)` を明示的に指定。

現状 `.cm-editor` (`&`) にしか `color` がなく、`.cm-content` は継承に頼っている。
スマホでバックグラウンド長時間放置→復帰→モーダル→閉じる のフローで
この継承が壊れ、本文テキストが背景色と同色になって見えなくなるバグがあった。

行番号（`.cm-gutters`）は `color: var(--text-muted)` が直接指定されているため影響なし。
ライト・ダーク両テーマに同じ修正を適用。