### PR TITLE
fix: WebGL カーソルトレイルのコンテキストロストに対応 (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Agasteerの変更履歴を記録しています。
 
 ---
 
+## 2026-04-20 - バグ修正
+
+### モバイル
+
+- **MDエディタ復帰時に本文が消える問題を修正**（#119）
+  - カーソルトレイル拡張の WebGL コンテキストロストを未処理だった
+  - `webglcontextlost` / `webglcontextrestored` ハンドラを追加し、復帰時に canvas を再生成
+  - `visibilitychange` で `gl.isContextLost()` を確認するフォールバックも追加（restored が発火しない端末対応）
+
+---
+
 ## 2026-02-11 - バグ修正
 
 ### GitHub同期

--- a/src/lib/editor/cursor-trail.ts
+++ b/src/lib/editor/cursor-trail.ts
@@ -369,7 +369,7 @@ export function createCursorTrailExtension(modules: {
   }
 
   function startLoop() {
-    if (destroyed || loopRunning) return
+    if (destroyed || loopRunning || contextLost) return
     loopRunning = true
     function frame() {
       if (destroyed || !loopRunning) return

--- a/src/lib/editor/cursor-trail.ts
+++ b/src/lib/editor/cursor-trail.ts
@@ -198,9 +198,37 @@ export function createCursorTrailExtension(modules: {
   let motionQuery: MediaQueryList | null = null
   let motionListener: ((e: MediaQueryListEvent) => void) | null = null
 
+  // WebGL コンテキストロスト復旧用に直近の editorEl を保持する
+  let lastEditorEl: HTMLElement | null = null
+  let visibilityListener: (() => void) | null = null
+
+  // GL リソースを開放し canvas も DOM から外す（visibility/contextlost 復旧と cleanup から共用）
+  function teardownGlResources() {
+    if (gl) {
+      if (buf) {
+        gl.deleteBuffer(buf)
+        buf = null
+      }
+      if (vao) {
+        gl.deleteVertexArray(vao)
+        vao = null
+      }
+      if (program) {
+        gl.deleteProgram(program)
+        program = null
+      }
+    }
+    if (canvas) {
+      canvas.remove()
+      canvas = null
+    }
+    gl = null
+  }
+
   function setupCanvas(editorEl: HTMLElement) {
     const scroller = editorEl.querySelector('.cm-scroller') as HTMLElement
     if (!scroller || canvas) return
+    lastEditorEl = editorEl
 
     // scroller の position を relative に（既に relative なら問題なし）
     const scrollerPosition = getComputedStyle(scroller).position
@@ -217,6 +245,19 @@ export function createCursorTrailExtension(modules: {
     canvas.style.pointerEvents = 'none'
     canvas.style.zIndex = '10'
     scroller.appendChild(canvas)
+
+    // モバイルのパワーセーブ復帰時に WebGL コンテキストが破棄されることがある。
+    // preventDefault() しないと restored は発火しない。
+    canvas.addEventListener('webglcontextlost', (e) => {
+      e.preventDefault()
+      stopLoop()
+      teardownGlResources()
+    })
+    canvas.addEventListener('webglcontextrestored', () => {
+      if (!destroyed && lastEditorEl) {
+        setupCanvas(lastEditorEl)
+      }
+    })
 
     gl = canvas.getContext('webgl2', { alpha: true, premultipliedAlpha: true })
     if (!gl) {
@@ -461,6 +502,19 @@ export function createCursorTrailExtension(modules: {
       }
     }
     motionQuery.addEventListener('change', motionListener)
+
+    // visibility 復帰時のフォールバック。webglcontextrestored が発火しない端末でも復旧できるよう、
+    // ロスト状態を検知したら teardown して再生成する。
+    visibilityListener = () => {
+      if (document.visibilityState !== 'visible') return
+      if (destroyed) return
+      if (gl && gl.isContextLost()) {
+        stopLoop()
+        teardownGlResources()
+        if (lastEditorEl) setupCanvas(lastEditorEl)
+      }
+    }
+    document.addEventListener('visibilitychange', visibilityListener)
   }
 
   function cleanupInternal() {
@@ -471,29 +525,16 @@ export function createCursorTrailExtension(modules: {
       scrollHandler = null
       scrollView = null
     }
-    if (gl) {
-      if (buf) {
-        gl.deleteBuffer(buf)
-        buf = null
-      }
-      if (vao) {
-        gl.deleteVertexArray(vao)
-        vao = null
-      }
-      if (program) {
-        gl.deleteProgram(program)
-        program = null
-      }
-    }
-    if (canvas) {
-      canvas.remove()
-      canvas = null
-    }
-    gl = null
+    teardownGlResources()
+    lastEditorEl = null
     if (motionQuery && motionListener) {
       motionQuery.removeEventListener('change', motionListener)
       motionQuery = null
       motionListener = null
+    }
+    if (visibilityListener) {
+      document.removeEventListener('visibilitychange', visibilityListener)
+      visibilityListener = null
     }
   }
 

--- a/src/lib/editor/cursor-trail.ts
+++ b/src/lib/editor/cursor-trail.ts
@@ -201,6 +201,9 @@ export function createCursorTrailExtension(modules: {
   // WebGL コンテキストロスト復旧用に直近の editorEl を保持する
   let lastEditorEl: HTMLElement | null = null
   let visibilityListener: (() => void) | null = null
+  // ロスト中フラグ。立っている間は updateListener から自動再生成しない
+  // （restored / visibility 経由で意図したタイミングだけ再生成する）
+  let contextLost = false
 
   // GL リソースを開放し canvas も DOM から外す（visibility/contextlost 復旧と cleanup から共用）
   function teardownGlResources() {
@@ -250,13 +253,14 @@ export function createCursorTrailExtension(modules: {
     // preventDefault() しないと restored は発火しない。
     canvas.addEventListener('webglcontextlost', (e) => {
       e.preventDefault()
+      contextLost = true
       stopLoop()
       teardownGlResources()
     })
     canvas.addEventListener('webglcontextrestored', () => {
-      if (!destroyed && lastEditorEl) {
-        setupCanvas(lastEditorEl)
-      }
+      contextLost = false
+      if (destroyed) return
+      if (lastEditorEl?.isConnected) setupCanvas(lastEditorEl)
     })
 
     gl = canvas.getContext('webgl2', { alpha: true, premultipliedAlpha: true })
@@ -469,8 +473,9 @@ export function createCursorTrailExtension(modules: {
 
   // ViewPlugin 定義
   const cursorTrailPlugin = EditorView.updateListener.of((update) => {
-    // エディタ初期化時に canvas をセットアップ
-    if (!canvas) {
+    // エディタ初期化時に canvas をセットアップ。
+    // contextLost 中は restored / visibility 経由でのみ再生成する。
+    if (!canvas && !contextLost) {
       setupCanvas(update.view.dom)
     }
 
@@ -508,11 +513,15 @@ export function createCursorTrailExtension(modules: {
     visibilityListener = () => {
       if (document.visibilityState !== 'visible') return
       if (destroyed) return
-      if (gl && gl.isContextLost()) {
-        stopLoop()
-        teardownGlResources()
-        if (lastEditorEl) setupCanvas(lastEditorEl)
-      }
+      // ロスト検知ルート2系統:
+      // (1) webglcontextlost が発火済みで contextLost フラグが立っている
+      // (2) restored が発火しない端末で gl は生きているが isContextLost() が true
+      const isLost = contextLost || (gl ? gl.isContextLost() : false)
+      if (!isLost) return
+      stopLoop()
+      teardownGlResources()
+      contextLost = false
+      if (lastEditorEl?.isConnected) setupCanvas(lastEditorEl)
     }
     document.addEventListener('visibilitychange', visibilityListener)
   }
@@ -526,6 +535,7 @@ export function createCursorTrailExtension(modules: {
       scrollView = null
     }
     teardownGlResources()
+    contextLost = false
     lastEditorEl = null
     if (motionQuery && motionListener) {
       motionQuery.removeEventListener('change', motionListener)


### PR DESCRIPTION
## 関連 Issue
closes #119

## 変更内容

スマホがパワーセーブから復帰した際、エディタ本文が消えたように見える不具合の修正。

- `cursor-trail.ts` の canvas 生成時に `webglcontextlost` / `webglcontextrestored` を購読
- ロスト時: `e.preventDefault()` してから GL リソース・canvas を完全 teardown
- restored 時: 保持していた `editorEl` で `setupCanvas` を再実行
- フォールバック: `visibilitychange` で `gl.isContextLost()` を確認し、ロスト検知時に再生成（restored が発火しない端末対策）
- 共通の teardown 経路を `teardownGlResources()` として切り出し、`cleanupInternal` からも利用

## 受け入れ条件

- [x] 型チェック通過 (svelte-check 0 errors)
- [x] フォーマット通過
- [ ] 実機: スマホでエディタを開いたままパワーセーブ→復帰でテキストが消えない
- [ ] 実機: 左上の壊れた画像アイコンが出ない
- [ ] 実機: カーソルトレイルが復帰後も動作する