### PR TITLE
fix: #121 設定画面テキスト入力のフォーカス喪失（実験A）

### DIFF
--- a/src/lib/app-state.svelte.ts
+++ b/src/lib/app-state.svelte.ts
@@ -679,7 +679,7 @@ export function initApp(deps: InitAppDeps): () => void {
   // 非同期初期化処理を即座に実行
   ;(async () => {
     const loadedSettings = await loadSettings()
-    settings.value = loadedSettings
+    Object.assign(settings.value, loadedSettings)
 
     // i18n初期化（翻訳読み込み完了を待機）
     await initI18n(loadedSettings.locale)

--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -31,7 +31,7 @@ export const settings = {
     return _settings
   },
   set value(v: Settings) {
-    _settings = v
+    Object.assign(_settings, v)
   },
 }
 

--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -30,6 +30,7 @@ export const settings = {
   get value() {
     return _settings
   },
+  // proxy 同一性を保つため置換ではなくフィールドごとにミューテートする（#121）
   set value(v: Settings) {
     Object.assign(_settings, v)
   },

--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -707,8 +707,8 @@ export const githubConfigured = {
 
 // ストアの更新と永続化をまとめたヘルパー関数
 export function updateSettings(newSettings: Settings): void {
-  settings.value = newSettings
-  saveSettings(newSettings)
+  Object.assign(_settings, newSettings)
+  saveSettings(_settings)
 }
 
 export function updateNotes(newNotes: Note[]): void {


### PR DESCRIPTION
## 関連 Issue
closes #121（の実験A部分）

## 変更内容

`updateSettings` を object 置換から `Object.assign` でのプロパティ書き換えに変更。

```diff
 export function updateSettings(newSettings: Settings): void {
-  settings.value = newSettings
-  saveSettings(newSettings)
+  Object.assign(_settings, newSettings)
+  saveSettings(_settings)
 }
```

## 仮説

Svelte 5 `$state` proxy は、参照を丸ごと差し替えると proxy 同一性が変わる。
`settings.value` を読む派生・effect が毎打鍵で再評価され、DOM 再評価に巻き込まれて input からフォーカスが抜けていた、というのが Issue #121 の本命仮説。

プロパティ代入なら proxy 同一性が保たれるため、変更されたフィールドだけ reactivity が走る。

## テスト方法

1. 設定画面を開く
2. 以下3つのテキスト入力で連続して文字を打つ:
   - ツール名
   - リポジトリ名
   - トークン
3. 1文字ごとにフォーカスが外れないことを確認

## 補足

Issue #121 には実験 A〜D を記載しているが、本 PR は A のみ。
これで直らなければ B/C/D を別 PR で試す切り分け方針。