### PR TITLE
fix: ホーム右下スタッツ背面グラデーションの端の途切れを解消

### DIFF
--- a/src/components/layout/StatsPanel.svelte
+++ b/src/components/layout/StatsPanel.svelte
@@ -32,8 +32,8 @@
     position: absolute;
     bottom: 40px; /* フッターの高さ */
     right: 0;
-    width: 400px;
-    height: 400px;
+    width: 1500px;
+    height: 1500px;
     background: linear-gradient(
       135deg,
       transparent 45%,

--- a/src/components/layout/StatsPanel.svelte
+++ b/src/components/layout/StatsPanel.svelte
@@ -32,12 +32,12 @@
     position: absolute;
     bottom: 40px; /* フッターの高さ */
     right: 0;
-    width: 1500px;
-    height: 1500px;
+    width: 400px;
+    height: 400px;
     background: linear-gradient(
       135deg,
-      transparent 45%,
-      color-mix(in srgb, var(--bg) 40%, transparent) 65%,
+      transparent 50%,
+      color-mix(in srgb, var(--bg) 40%, transparent) 70%,
       color-mix(in srgb, var(--bg) 60%, transparent) 100%
     );
     pointer-events: none;


### PR DESCRIPTION
## 症状

ホーム右下のスタッツ背面、135deg グラデーションの斜め band の左下端・右上端が、矩形の左辺・上辺と交差して急に途切れて見えていた。

## 修正

`src/components/layout/StatsPanel.svelte` の `.stats-overlay` のグラデーション stops を
45% / 65% / 100% → 50% / 70% / 100% に調整。矩形サイズ（400×400）はそのまま。

band を右下コーナー寄りにシフトすることで、band の端が矩形の左辺・上辺と交差する位置を後ろに押し出し、途切れを目立たなくする。

## 経緯

最初は矩形を拡大する方針で試したが、箱を大きくするとグラデーション band の「見える範囲」が濃い側に偏り、影そのものが見えなくなったため、stops の調整方針に切り替えた。