### PR TITLE
feat: #125 staleポップアップに診断情報（SHA/pushCount）を表示

### DIFF
--- a/src/lib/actions/git.ts
+++ b/src/lib/actions/git.ts
@@ -107,7 +107,19 @@ export async function pushToGitHub(): Promise<void> {
       console.log(
         `Push blocked: remote(${staleResult.remoteCommitSha}) !== local(${staleResult.localCommitSha})`
       )
-      const choice = await choiceAsync($_('modal.staleEdit'), [
+      // 診断情報: ローカル/リモートのpushCountとSHAを付与し、誤検出に気付けるようにする
+      const remotePushCountResult = await fetchRemotePushCount(settings.value)
+      const remotePushCount =
+        remotePushCountResult.status === 'success' ? remotePushCountResult.pushCount : '?'
+      const diagnostic = $_('modal.staleEditDiagnostic', {
+        values: {
+          localSha: (staleResult.localCommitSha ?? 'null').slice(0, 7),
+          remoteSha: staleResult.remoteCommitSha.slice(0, 7),
+          localCount: metadata.value.pushCount,
+          remoteCount: remotePushCount,
+        },
+      })
+      const choice = await choiceAsync($_('modal.staleEdit') + diagnostic, [
         { label: $_('modal.pullFirst'), value: 'pull', variant: 'primary', icon: PULL_ICON },
         { label: $_('modal.pushOverwrite'), value: 'push', variant: 'secondary', icon: PUSH_ICON },
         { label: $_('modal.cancel'), value: 'cancel', variant: 'cancel' },

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -263,6 +263,7 @@
   "modal": {
     "longBackground": "You were away for a while. Checking current state.",
     "staleEdit": "Remote has newer changes.\nSaving will overwrite them.",
+    "staleEditDiagnostic": "\n\nLocal: {localSha} (push #{localCount})\nRemote: {remoteSha} (push #{remoteCount})",
     "unsavedChanges": "You have unsaved changes. Pull will overwrite them. Continue?",
     "unsavedChangesOnStartup": "Your previous edits were not saved to GitHub.\nPulling will lose them. Pull anyway?\n\nSelect 'Cancel' to keep local changes.",
     "unsavedChangesChoice": "You have unsaved changes.\nPulling will overwrite them.",

--- a/src/lib/i18n/locales/ja.json
+++ b/src/lib/i18n/locales/ja.json
@@ -264,6 +264,7 @@
   "modal": {
     "longBackground": "長時間バックグラウンドでした。現在の状態を確認します。",
     "staleEdit": "リモートに新しい変更があります。\nこのまま保存すると上書きされます。",
+    "staleEditDiagnostic": "\n\nローカル: {localSha} (push #{localCount})\nリモート: {remoteSha} (push #{remoteCount})",
     "unsavedChanges": "未保存の変更があります。Pullすると上書きされます。続行しますか？",
     "unsavedChangesOnStartup": "前回の編集内容がGitHubに保存されていません。\nPullすると失われます。Pullしますか？\n\n「キャンセル」を選ぶとローカルの変更を保持します。",
     "unsavedChangesChoice": "未保存の変更があります。\nPullすると上書きされます。",


### PR DESCRIPTION
## 背景

#125 の Bug B（誤pullポップアップ）が PR #126 の修正後も再発するとの報告あり。
原因特定のため、staleポップアップに診断情報を出して目視で判別できるようにする。

## 変更

staleポップアップのメッセージ末尾に次の情報を追加:

```
ローカル: 942aa68 (push #392)
リモート: 942aa68 (push #392)
```

- SHA が一致しているのにpopupが出ていれば、stale検出ロジック側のバグ
- SHA が違えば、本当にリモートが進んでいる（別端末のpush等）

pushCount も併記することで、別端末のpush頻度や初期化漏れも気付ける。

## 変更ファイル
- `src/lib/actions/git.ts` — staleブランチで `fetchRemotePushCount` を呼び、診断文字列を合成
- `src/lib/i18n/locales/ja.json` / `en.json` — 新キー `modal.staleEditDiagnostic` 追加

## Test plan
- [ ] stale popup が出る状況を再現し、SHA/pushCount が両側表示されること
- [ ] SHA が同じ値で表示されるケースが存在するか確認（= Bug B の根本原因の手がかり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)