### PR TITLE
fix: #125 可変リソースGETのキャッシュ無効化（push履歴喪失・1件push誤報告の根本修正）

### DIFF
--- a/docs/development/sync/github-api.md
+++ b/docs/development/sync/github-api.md
@@ -397,6 +397,28 @@ GitHub Contents API呼び出しにキャッシュバスター（`?t=${Date.now()
 - ✅ リーフコンテンツも常に最新
 - ✅ キャッシュバスターの管理が一元化（保守性向上）
 
+### Git Data API の ref/tree 取得にも `cache: 'no-store'` が必須
+
+Contents API だけでなく **Git Data API のブランチ参照系 GET にも同じキャッシュ問題**がある。ref や「ブランチ名で引くツリー」はブランチHEADに追従する可変リソースなので、キャッシュされた応答で古いSHAを返す可能性がある。
+
+**具体的な影響（過去に発生した不具合）:**
+
+`pushAllWithTreeAPI` の ref 取得にキャッシュ対策が欠けていた結果:
+
+1. 連続push時に **古いHEAD SHA** を取得
+2. その古い commit を親として新 commit を作成
+3. ブランチ更新は `force: true` のため **実HEADを上書きして消す**
+4. 既存ツリーも古い参照から取得するため local leaf SHA と合わず、毎回「1件push」と誤報告
+5. pushで帳尻が合わず、pullするまで解消しない（pullは fresh fetchするため）
+
+**対策（適用済み）:** 以下の GET すべてに `cache: 'no-store'` を付与:
+
+- `/repos/{repoName}` （default_branch 取得、push/pull/staleCheck/pullArchive 全経路）
+- `/repos/{repoName}/git/ref/heads/{branch}` （ref 取得、全経路）
+- `/repos/{repoName}/git/trees/{branch}?recursive=1` （ブランチ名でのツリー取得、pull/pullArchive）
+
+一方、SHA アドレスで取得する `/git/commits/{sha}` `/git/trees/{sha}` `/git/blobs/{sha}` は **content-addressed で不変**なのでキャッシュしても安全。むしろキャッシュヒットが望ましい。
+
 ---
 
 ## ファイルパスの構築

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -524,9 +524,11 @@ export async function pushAllWithTreeAPI(
     const branch = repoData.default_branch || 'main'
 
     // 2. 現在のブランチのHEADを取得
+    // cache: 'no-store' は必須。キャッシュされたref値で push すると stale な parent の上に
+    // 新 commit を作り、force push で実 HEAD を上書きして履歴を失う（兄弟コミット量産）。
     const refRes = await fetch(
       `https://api.github.com/repos/${settings.repoName}/git/ref/heads/${branch}`,
-      { headers }
+      { headers, cache: 'no-store' }
     )
     // レート制限チェック
     const refRateLimit = parseRateLimitResponse(refRes)
@@ -1197,10 +1199,11 @@ export async function pullFromGitHub(
     const defaultBranch = repoData.default_branch || 'main'
 
     // HEAD commit SHAを取得（stale検出用）
+    // cache: 'no-store' は必須。キャッシュで古いSHAを拾うと stale検出が狂う。
     let pullCommitSha: string | undefined
     const refRes = await fetch(
       `https://api.github.com/repos/${settings.repoName}/git/ref/heads/${defaultBranch}`,
-      { headers }
+      { headers, cache: 'no-store' }
     )
     if (refRes.ok) {
       const refData = await refRes.json()

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -500,7 +500,10 @@ export async function pushAllWithTreeAPI(
 
   try {
     // 1. デフォルトブランチを取得
-    const repoRes = await fetch(`https://api.github.com/repos/${settings.repoName}`, { headers })
+    const repoRes = await fetch(`https://api.github.com/repos/${settings.repoName}`, {
+      headers,
+      cache: 'no-store',
+    })
     // レート制限チェック
     const repoRateLimit = parseRateLimitResponse(repoRes)
     if (repoRateLimit.isRateLimited) {
@@ -1146,7 +1149,10 @@ export async function pullFromGitHub(
   }
 
   try {
-    const repoRes = await fetch(`https://api.github.com/repos/${settings.repoName}`, { headers })
+    const repoRes = await fetch(`https://api.github.com/repos/${settings.repoName}`, {
+      headers,
+      cache: 'no-store',
+    })
     if (repoRes.status === 404) {
       return {
         success: false,
@@ -1211,10 +1217,10 @@ export async function pullFromGitHub(
     }
     // refRes失敗時（空リポジトリ等）はpullCommitSha=undefinedのまま続行
 
-    // tree取得
+    // tree取得（ブランチ名参照なので可変 → cache: 'no-store' 必須）
     const treeRes = await fetch(
       `https://api.github.com/repos/${settings.repoName}/git/trees/${defaultBranch}?recursive=1`,
-      { headers }
+      { headers, cache: 'no-store' }
     )
 
     // レート制限チェック（tree）
@@ -1683,7 +1689,7 @@ export async function testGitHubConnection(settings: Settings): Promise<TestResu
 
   try {
     // 認証確認
-    const userRes = await fetch('https://api.github.com/user', { headers })
+    const userRes = await fetch('https://api.github.com/user', { headers, cache: 'no-store' })
     if (userRes.status === 401) {
       return {
         success: false,
@@ -1713,7 +1719,10 @@ export async function testGitHubConnection(settings: Settings): Promise<TestResu
     }
 
     // リポジトリ参照確認
-    const repoRes = await fetch(`https://api.github.com/repos/${settings.repoName}`, { headers })
+    const repoRes = await fetch(`https://api.github.com/repos/${settings.repoName}`, {
+      headers,
+      cache: 'no-store',
+    })
     if (repoRes.status === 404) {
       return {
         success: false,
@@ -1825,7 +1834,10 @@ export async function pullArchive(
 
   try {
     // リポジトリ情報を取得
-    const repoRes = await fetch(`https://api.github.com/repos/${settings.repoName}`, { headers })
+    const repoRes = await fetch(`https://api.github.com/repos/${settings.repoName}`, {
+      headers,
+      cache: 'no-store',
+    })
     if (repoRes.status === 404) {
       return {
         success: false,
@@ -1865,10 +1877,10 @@ export async function pullArchive(
     const repoData = await repoRes.json()
     const defaultBranch = repoData.default_branch || 'main'
 
-    // tree取得
+    // tree取得（ブランチ名参照なので可変 → cache: 'no-store' 必須）
     const treeRes = await fetch(
       `https://api.github.com/repos/${settings.repoName}/git/trees/${defaultBranch}?recursive=1`,
-      { headers }
+      { headers, cache: 'no-store' }
     )
 
     const treeRateLimit = parseRateLimitResponse(treeRes)


### PR DESCRIPTION
## 根本原因

`pushAllWithTreeAPI` の ref 取得に \`cache: 'no-store'\` が欠けていたため、ブラウザ/Service Worker/CDNのキャッシュで **古いHEAD SHA** を拾うケースがあった。これが #125 のBug A/B両方の根本原因。

実測: GitHub PushEvents API で同じ parent (\`94d7855\`) を持つ兄弟コミットが5本並んでいることを確認。

```
0874e87 parent=94d7855
67ca3a8 parent=94d7855   ← force pushで上書きされて消えた
1598df9 parent=94d7855   ← force pushで上書きされて消えた
7bece3e parent=94d7855   ← force pushで上書きされて消えた
94d7855
```

## 発生していた事象

1. 古いHEAD SHAを parent として新 commit を作成
2. Ref PATCH \`force: true\` で実HEAD を上書き → 履歴が喪失
3. 既存ツリーも古い参照から取得されるため local leaf SHA と合わず、毎回「1件push」と誤報告
4. push だけでは永久に帳尻が合わず、pull すると fresh な tree を取り直して解消

## 修正

可変リソースの GET すべてに \`cache: 'no-store'\` を追加:

| 関数 | 対象エンドポイント |
|---|---|
| \`pushAllWithTreeAPI\` | \`/repos/{repo}\`, \`/git/ref/heads/{branch}\` |
| \`pullFromGitHub\` | \`/repos/{repo}\`, \`/git/ref/heads/{branch}\`, \`/git/trees/{branch}?recursive=1\` |
| \`pullArchive\` | \`/repos/{repo}\`, \`/git/trees/{branch}?recursive=1\` |
| \`testGitHubConnection\` | \`/user\`, \`/repos/{repo}\` |
| \`fetchRemoteHeadSha\` | （既に付与済み） |

SHA アドレス参照の \`/git/commits/{sha}\` \`/git/trees/{sha}\` \`/git/blobs/{sha}\` は content-addressed で不変のためキャッシュ可、無変更。

## docs

\`docs/development/sync/github-api.md\` に ref キャッシュ問題の節を追加。既存の Contents API キャッシュ問題の解説と並べて記載。

## refs #125

Bug A（「1件push」誤トースト）とBug B（誤stale popup）の両方を根本から修正。PR #126（noChanges時のSHA更新）とPR #127（診断情報表示）に続く本命の修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)