### PR TITLE
fix: #134 同期中のリポ切替後に予約pullする

### DIFF
--- a/docs/development/sync/push-pull.md
+++ b/docs/development/sync/push-pull.md
@@ -432,7 +432,7 @@ Pull失敗時のバックアップ復元は**初回Pull（`isInitialStartup = tr
 
 さらに、**トークンまたはリポジトリ名が空の場合**（`hasValidConfig = false`）は**Pullを実行せず、初回Pull前の状態に戻す**（`isPullCompleted = false` → `isFirstPriorityFetched = false` + `resetForRepoSwitch()` + `archiveLeafStatsStore.reset()`）。これにより、設定が不完全な状態でデータ操作が行われることを防ぐ。
 
-Pull/Push/アーカイブロード中に設定画面を閉じた場合は、新しいPullを発行せずリセット済みの状態で閉じる（`resetForRepoSwitch()`で既にデータがクリアされているため、次回操作時に新リポからPullされる）。
+Pull/Push/アーカイブロード中に設定画面を閉じた場合は、即時Pullではなく**予約Pull**に切り替える。`pendingRepoSync = true` を立て、進行中の同期処理が完了した直後に、最新の `settings.repoName` / `settings.token` に対して `pullFromGitHub(false)` を1回だけ自動実行する。
 
 **Pullが失敗した場合**も同様に、`isPullCompleted = false`となるため初回Pull前の状態にリセットされる（`isFirstPriorityFetched = false` + `resetForRepoSwitch()` + `archiveLeafStatsStore.reset()`）。
 
@@ -669,15 +669,15 @@ sequenceDiagram
 
 #### Aランク（重大 — 誤動作の可能性）
 
-| #   | 操作シナリオ                               | 期待動作                                 | 対応するガード/関数                                                                                        | 深刻度 |
-| --- | ------------------------------------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- | :----: |
-| 6   | Pull中にリポ切替                           | 進行中Pullが旧リポデータを注入しない     | `handleCloseSettings()` → `isPulling`チェック → 新Pullスキップ                                             |   A    |
-| 7   | Push中にリポ切替                           | 旧リポへのPushは完了し新リポに影響しない | `handleCloseSettings()` → `isPushing`チェック → 新Pullスキップ                                             |   A    |
-| 8   | アーカイブロード中にリポ切替               | アーカイブPullの結果が破棄される         | `handleCloseSettings()` → `isArchiveLoading`チェック → 新Pullスキップ。`isArchiveLoaded=false`で再Pull必要 |   A    |
-| 9   | lastKnownCommitShaが旧リポのまま残る       | staleチェックが新リポのSHAと比較する     | `resetForRepoSwitch()` → `lastKnownCommitSha.set(null)` → 初回Pull扱い                                     |   A    |
-| 10  | lastPushedSnapshotが旧リポのまま残る       | dirty検出が新リポ基準で動作する          | `resetForRepoSwitch()` → 全スナップショット配列を`[]`にクリア                                              |   A    |
-| 11  | 自動Push（42秒タイマー）がリポ切替後に発火 | 旧データを新リポにPushしない             | `resetForRepoSwitch()` → `clearAllChanges()` → `isDirty=false` → 自動Push条件不成立                        |   A    |
-| 12  | staleチェックがリポ切替をまたぐ            | 旧リポのSHAでstale判定しない             | `lastStaleCheckTime=0` → `canPerformCheck()=false` → 新Pull完了までチェック抑制                            |   A    |
+| #   | 操作シナリオ                               | 期待動作                                | 対応するガード/関数                                                                     | 深刻度 |
+| --- | ------------------------------------------ | --------------------------------------- | --------------------------------------------------------------------------------------- | :----: |
+| 6   | Pull中にリポ切替                           | 進行中Pull完了後に新repo pullへ収束する | `handleCloseSettings()` → `pendingRepoSync=true` → Pull finally後に予約pull実行         |   A    |
+| 7   | Push中にリポ切替                           | Push完了後に新repo pullへ収束する       | `handleCloseSettings()` → `pendingRepoSync=true` → Push finally後に予約pull実行         |   A    |
+| 8   | アーカイブロード中にリポ切替               | archive完了後に新repo pullへ収束する    | `handleCloseSettings()` → `pendingRepoSync=true` → archive load finally後に予約pull実行 |   A    |
+| 9   | lastKnownCommitShaが旧リポのまま残る       | staleチェックが新リポのSHAと比較する    | `resetForRepoSwitch()` → `lastKnownCommitSha.set(null)` → 初回Pull扱い                  |   A    |
+| 10  | lastPushedSnapshotが旧リポのまま残る       | dirty検出が新リポ基準で動作する         | `resetForRepoSwitch()` → 全スナップショット配列を`[]`にクリア                           |   A    |
+| 11  | 自動Push（42秒タイマー）がリポ切替後に発火 | 旧データを新リポにPushしない            | `resetForRepoSwitch()` → `clearAllChanges()` → `isDirty=false` → 自動Push条件不成立     |   A    |
+| 12  | staleチェックがリポ切替をまたぐ            | 旧リポのSHAでstale判定しない            | `lastStaleCheckTime=0` → `canPerformCheck()=false` → 新Pull完了までチェック抑制         |   A    |
 
 #### Bランク（UX問題 — 動作はするが改善が望ましい）
 
@@ -794,11 +794,10 @@ sequenceDiagram
 **修正後:**
 
 - `handleCloseSettings()`で`isPulling.value || isPushing.value || isArchiveLoading`をチェック
-- いずれかがtrueの場合、新Pullを発行しない
-- `resetForRepoSwitch()`で既にデータクリア済みなので、旧Pullの結果は無害
-  - 旧Pullが`notes.set()`等を呼んでも、すぐ後に`handleCloseSettings()`でPullが走らないため混在しない
-  - ユーザーが手動でPullを実行すれば新リポからデータ取得される
-- **結果: 安全。クリア済み状態で閉じ、次回操作時に新リポからPull**
+- いずれかがtrueの場合、即時Pullではなく `pendingRepoSync = true` を記録
+- `resetForRepoSwitch()`で既にデータクリア済みなので、進行中の旧Pull結果は操作対象として残らない
+- 進行中の同期が finally に入った時点で予約を確認し、新repo pull を1回だけ実行する
+- **結果: 安全性を保ったまま、自動で新リポへ収束する**
 
 ---
 

--- a/src/lib/actions/git.ts
+++ b/src/lib/actions/git.ts
@@ -57,6 +57,26 @@ import { tick } from 'svelte'
 import { get } from 'svelte/store'
 import { _ } from '../i18n'
 import { PULL_ICON, PUSH_ICON } from '../ui/icons'
+import { runPendingRepoSyncIfIdle as runPendingRepoSyncIfIdleShared } from '../sync/repo-sync-queue'
+
+async function runPendingRepoSyncIfIdle(): Promise<void> {
+  const hasValidConfig = !!(settings.value.token && settings.value.repoName)
+  await runPendingRepoSyncIfIdleShared(
+    {
+      isPulling: isPulling.value,
+      isPushing: isPushing.value,
+      isArchiveLoading: appState.isArchiveLoading,
+    },
+    hasValidConfig,
+    appState.pendingRepoSync,
+    () => {
+      appState.pendingRepoSync = false
+    },
+    async () => {
+      await pullFromGitHub(false)
+    }
+  )
+}
 
 /**
  * GitHub接続テスト
@@ -205,6 +225,7 @@ export async function pushToGitHub(): Promise<void> {
     }
   } finally {
     isPushing.value = false
+    await runPendingRepoSyncIfIdle()
   }
 }
 
@@ -460,5 +481,6 @@ export async function pullFromGitHub(
     pullProgressStore.reset()
   } finally {
     isPulling.value = false
+    await runPendingRepoSyncIfIdle()
   }
 }

--- a/src/lib/actions/move.ts
+++ b/src/lib/actions/move.ts
@@ -38,6 +38,26 @@ import { pullArchive, translateGitHubMessage } from '../api'
 import { generateUniqueName } from '../utils'
 import { appState, appActions, getWorldForPane } from '../app-state.svelte'
 import { _ } from '../i18n'
+import { runPendingRepoSyncIfIdle } from '../sync/repo-sync-queue'
+
+async function runPendingRepoSyncAfterArchiveLoad(): Promise<void> {
+  const hasValidConfig = !!(settings.value.token && settings.value.repoName)
+  await runPendingRepoSyncIfIdle(
+    {
+      isPulling: isPulling.value,
+      isPushing: isPushing.value,
+      isArchiveLoading: appState.isArchiveLoading,
+    },
+    hasValidConfig,
+    appState.pendingRepoSync,
+    () => {
+      appState.pendingRepoSync = false
+    },
+    async () => {
+      await appActions.pullFromGitHub(false)
+    }
+  )
+}
 
 /**
  * ノートをワールド間で移動する（Home ⇔ Archive）
@@ -104,6 +124,7 @@ export async function moveNoteToWorld(
         return
       } finally {
         appState.isArchiveLoading = false
+        await runPendingRepoSyncAfterArchiveLoad()
       }
     } else {
       // GitHub設定がない場合は到達しないはず（ガラス効果でブロックされる）
@@ -390,6 +411,7 @@ export async function moveLeafToWorld(
         return
       } finally {
         appState.isArchiveLoading = false
+        await runPendingRepoSyncAfterArchiveLoad()
       }
     } else {
       // GitHub設定がない場合は到達しないはず（ガラス効果でブロックされる）

--- a/src/lib/app-state.svelte.ts
+++ b/src/lib/app-state.svelte.ts
@@ -205,6 +205,7 @@ let _leafSkeletonMap = $state(new Map<string, LeafSkeleton>())
 let _isRestoringFromUrl = $state(false)
 let _importOccurredInSettings = $state(false)
 let _atGuardEntry = $state(false)
+let _pendingRepoSync = $state(false)
 
 export const appState = {
   get breadcrumbs() {
@@ -369,6 +370,12 @@ export const appState = {
   set atGuardEntry(v: boolean) {
     _atGuardEntry = v
   },
+  get pendingRepoSync() {
+    return _pendingRepoSync
+  },
+  set pendingRepoSync(v: boolean) {
+    _pendingRepoSync = v
+  },
 }
 
 // ========================================
@@ -389,6 +396,10 @@ export interface AppActionsRegistry {
   closeMoveModal: () => void
   updateOfflineContent: (content: string) => void
   pushToGitHub: () => Promise<void>
+  pullFromGitHub: (
+    isInitialStartup?: boolean,
+    onCancel?: () => void | Promise<void>
+  ) => Promise<void>
   showPrompt: (
     message: string,
     onConfirm: (value: string) => void,

--- a/src/lib/pane-actions-factory.svelte.ts
+++ b/src/lib/pane-actions-factory.svelte.ts
@@ -11,6 +11,7 @@ import type { Note, Leaf, Breadcrumb } from './types'
 import type { Pane } from './navigation'
 import type { PaneActions } from './stores'
 import { _ } from './i18n'
+import { shouldQueueRepoSync } from './sync/repo-sync-queue'
 import { locale } from 'svelte-i18n'
 import {
   settings,
@@ -405,13 +406,25 @@ export async function handleCloseSettings() {
   if (githubSettingsChangedInSettings || appState.importOccurredInSettings) {
     const hasValidConfig = !!(settings.value.token && settings.value.repoName)
     if (hasValidConfig) {
-      if (!isPulling.value && !isPushing.value && !appState.isArchiveLoading) {
+      if (
+        shouldQueueRepoSync(
+          {
+            isPulling: isPulling.value,
+            isPushing: isPushing.value,
+            isArchiveLoading: appState.isArchiveLoading,
+          },
+          hasValidConfig
+        )
+      ) {
+        appState.pendingRepoSync = true
+      } else {
         isClosingSettingsPull = true
         await pullFromGitHub(false)
         isClosingSettingsPull = false
       }
     } else {
       appState.isPullCompleted = false
+      appState.pendingRepoSync = false
     }
     // pull失敗または設定が不完全 → 初回pull前の状態に戻す
     if (!appState.isPullCompleted) {
@@ -528,6 +541,7 @@ export function setupAppActionsAndContext(pushDisabledReasonGetter: () => string
     closeMoveModal,
     updateOfflineContent,
     pushToGitHub,
+    pullFromGitHub,
     showPrompt,
     showConfirm,
     getDialogPositionForPane,

--- a/src/lib/pane-navigation.svelte.ts
+++ b/src/lib/pane-navigation.svelte.ts
@@ -18,6 +18,7 @@ import {
 import type { Pane } from './navigation'
 import type { EditorPaneRef } from './editor/editor-pane-ref'
 import { waitForMatchingEditor } from './editor/wait-for-editor'
+import { runPendingRepoSyncIfIdle as runPendingRepoSyncIfIdleShared } from './sync/repo-sync-queue'
 import * as nav from './navigation'
 import { resolvePath, buildPath, extractWorldPrefix } from './navigation'
 import { _ } from './i18n'
@@ -51,7 +52,13 @@ import {
   setArchiveBaseline,
   scheduleOfflineSave,
 } from './stores'
-import { appState, derivedState, getNotesForPane, getLeavesForPane } from './app-state.svelte'
+import {
+  appActions,
+  appState,
+  derivedState,
+  getNotesForPane,
+  getLeavesForPane,
+} from './app-state.svelte'
 import {
   priorityItems,
   createPriorityLeaf,
@@ -122,6 +129,25 @@ export function syncNavState(state: nav.NavigationState) {
   focusedPane.value = state.focusedPane
   appState.selectedIndexLeft = state.selectedIndexLeft
   appState.selectedIndexRight = state.selectedIndexRight
+}
+
+async function runPendingRepoSyncIfIdle(): Promise<void> {
+  const hasValidConfig = !!(settings.value.token && settings.value.repoName)
+  await runPendingRepoSyncIfIdleShared(
+    {
+      isPulling: isPulling.value,
+      isPushing: isPushing.value,
+      isArchiveLoading: appState.isArchiveLoading,
+    },
+    hasValidConfig,
+    appState.pendingRepoSync,
+    () => {
+      appState.pendingRepoSync = false
+    },
+    async () => {
+      await appActions.pullFromGitHub(false)
+    }
+  )
 }
 
 // ========================================
@@ -380,6 +406,7 @@ export async function handleWorldChange(world: WorldType, pane: Pane = 'left') {
         }
       } finally {
         appState.isArchiveLoading = false
+        await runPendingRepoSyncIfIdle()
       }
     }
   }
@@ -797,6 +824,7 @@ export async function restoreStateFromUrl(alreadyRestoring = false) {
       }
     } finally {
       appState.isArchiveLoading = false
+      await runPendingRepoSyncIfIdle()
     }
   }
 

--- a/src/lib/sync/repo-sync-queue.test.ts
+++ b/src/lib/sync/repo-sync-queue.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  canRunPendingRepoSync,
+  isRepoSyncBusy,
+  runPendingRepoSyncIfIdle,
+  shouldQueueRepoSync,
+} from './repo-sync-queue'
+
+describe('repo sync queue', () => {
+  it('treats pull, push, and archive loading as busy states', () => {
+    expect(isRepoSyncBusy({ isPulling: true, isPushing: false, isArchiveLoading: false })).toBe(
+      true
+    )
+    expect(isRepoSyncBusy({ isPulling: false, isPushing: true, isArchiveLoading: false })).toBe(
+      true
+    )
+    expect(isRepoSyncBusy({ isPulling: false, isPushing: false, isArchiveLoading: true })).toBe(
+      true
+    )
+    expect(isRepoSyncBusy({ isPulling: false, isPushing: false, isArchiveLoading: false })).toBe(
+      false
+    )
+  })
+
+  it('queues repo sync only when config is valid and another sync is in flight', () => {
+    expect(
+      shouldQueueRepoSync({ isPulling: true, isPushing: false, isArchiveLoading: false }, true)
+    ).toBe(true)
+    expect(
+      shouldQueueRepoSync({ isPulling: false, isPushing: false, isArchiveLoading: false }, true)
+    ).toBe(false)
+    expect(
+      shouldQueueRepoSync({ isPulling: true, isPushing: false, isArchiveLoading: false }, false)
+    ).toBe(false)
+  })
+
+  it('runs pending repo sync only after all sync activity is idle', () => {
+    expect(
+      canRunPendingRepoSync(
+        { isPulling: false, isPushing: false, isArchiveLoading: false },
+        true,
+        true
+      )
+    ).toBe(true)
+    expect(
+      canRunPendingRepoSync(
+        { isPulling: false, isPushing: true, isArchiveLoading: false },
+        true,
+        true
+      )
+    ).toBe(false)
+    expect(
+      canRunPendingRepoSync(
+        { isPulling: false, isPushing: false, isArchiveLoading: false },
+        false,
+        true
+      )
+    ).toBe(false)
+    expect(
+      canRunPendingRepoSync(
+        { isPulling: false, isPushing: false, isArchiveLoading: false },
+        true,
+        false
+      )
+    ).toBe(false)
+  })
+
+  it('clears pending and triggers pull exactly once when idle', async () => {
+    let cleared = 0
+    let pulled = 0
+
+    const executed = await runPendingRepoSyncIfIdle(
+      { isPulling: false, isPushing: false, isArchiveLoading: false },
+      true,
+      true,
+      () => {
+        cleared += 1
+      },
+      async () => {
+        pulled += 1
+      }
+    )
+
+    expect(executed).toBe(true)
+    expect(cleared).toBe(1)
+    expect(pulled).toBe(1)
+  })
+})

--- a/src/lib/sync/repo-sync-queue.ts
+++ b/src/lib/sync/repo-sync-queue.ts
@@ -1,0 +1,40 @@
+export interface RepoSyncActivityState {
+  isPulling: boolean
+  isPushing: boolean
+  isArchiveLoading: boolean
+}
+
+export function isRepoSyncBusy(state: RepoSyncActivityState): boolean {
+  return state.isPulling || state.isPushing || state.isArchiveLoading
+}
+
+export function shouldQueueRepoSync(
+  state: RepoSyncActivityState,
+  hasValidConfig: boolean
+): boolean {
+  return hasValidConfig && isRepoSyncBusy(state)
+}
+
+export function canRunPendingRepoSync(
+  state: RepoSyncActivityState,
+  hasValidConfig: boolean,
+  pendingRepoSync: boolean
+): boolean {
+  return pendingRepoSync && hasValidConfig && !isRepoSyncBusy(state)
+}
+
+export async function runPendingRepoSyncIfIdle(
+  state: RepoSyncActivityState,
+  hasValidConfig: boolean,
+  pendingRepoSync: boolean,
+  clearPendingRepoSync: () => void,
+  triggerPull: () => Promise<void>
+): Promise<boolean> {
+  if (!canRunPendingRepoSync(state, hasValidConfig, pendingRepoSync)) {
+    return false
+  }
+
+  clearPendingRepoSync()
+  await triggerPull()
+  return true
+}


### PR DESCRIPTION
## 関連 Issue
closes #134

## 変更内容
- repo / token 変更後に設定を閉じたとき、Pull / Push / Archive load 中なら `pendingRepoSync` を立てて即時 pull ではなく予約に切り替えるよう修正
- Push / Pull / archive load 完了後に、最新 settings を使って新 repo pull を 1 回だけ自動実行する共有 helper を追加
- archive load の全経路（`handleWorldChange` / `restoreStateFromUrl` / `moveNoteToWorld` / `moveLeafToWorld`）で予約 pull 消費を統一
- 同期フロー docs を予約 pull 仕様に更新
- `repo-sync-queue` の単体テストを追加

## 検証
- `npm run test`
- `npm run check`
- `npm run format:check`
- コミット時の `npm run lint`

## セルフレビュー
- review スキル相当で独立サブエージェントレビューを実施
- 初回レビューの指摘（archive load 経路の取りこぼし、shared helper 重複整理、docs 整合性）を全件修正済み
- 再レビュー結果: Approve
