### PR TITLE
fix: #130 リポ切替時に旧リポのペイン表示を即クリア

### DIFF
--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -789,11 +789,15 @@ export function resetForRepoSwitch(): void {
   rightWorld.value = 'home'
 
   // 旧リポのノート/リーフを開いたまま残さない
-  // （予約pull待ちや未設定経路でもペインが旧データを指さないよう即クリア）
-  _leftNote = null
-  _rightNote = null
-  _leftLeaf = null
-  _rightLeaf = null
-  _leftView = 'home'
-  _rightView = 'home'
+  // pullFromGitHub 側でも pane クリアしているが、以下の経路ではそこに到達しない:
+  // 1. 設定確定〜pullFromGitHub 開始までの非同期ギャップ
+  // 2. 同期中 repo 切替による予約pull 待機中（#134）
+  // 3. token/repoName 未設定で pull が走らない無効経路
+  // view も 'home' に戻すことで、null leaf を edit しようとする reactive effect を防止
+  leftNote.value = null
+  rightNote.value = null
+  leftLeaf.value = null
+  rightLeaf.value = null
+  leftView.value = 'home'
+  rightView.value = 'home'
 }

--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -787,4 +787,13 @@ export function resetForRepoSwitch(): void {
   // ワールドをホームに戻す（旧リポのアーカイブ表示を防止）
   leftWorld.value = 'home'
   rightWorld.value = 'home'
+
+  // 旧リポのノート/リーフを開いたまま残さない
+  // （予約pull待ちや未設定経路でもペインが旧データを指さないよう即クリア）
+  _leftNote = null
+  _rightNote = null
+  _leftLeaf = null
+  _rightLeaf = null
+  _leftView = 'home'
+  _rightView = 'home'
 }


### PR DESCRIPTION
## 関連 Issue
Refs #130（親Issueのため close せず、期待挙動1の部分対応）

## 問題
`resetForRepoSwitch()` はワールドや Git参照・dirty・archive 等をリセットしていたが、**pane（leftNote/leftLeaf/rightNote/rightLeaf と view）をクリアしていなかった**ため、以下の経路で旧リポのリーフが表示されたまま残るケースがあった:

- 同期中に repo 切替した場合の予約pull待ち時間（#134 のキュー待機中）
- GitHub トークンや repoName が未設定の無効経路
- `handleCloseSettings` で `pullFromGitHub` に到達しないケース

`pullFromGitHub` 側では pane クリアしているが、pull に到達しない経路ではクリアされず、Issue #130 期待挙動1「repo を切り替えたら、旧リポの leaf を開いたままにしない」に違反していた。

## 修正
`resetForRepoSwitch()`（`src/lib/stores/stores.svelte.ts`）で pane と view をクリアする。

```ts
_leftNote = null
_rightNote = null
_leftLeaf = null
_rightLeaf = null
_leftView = 'home'
_rightView = 'home'
```

同じファイル内の内部変数なので直接代入。外部からは既存 getter/setter 経由でアクセスされる。

## スコープ外（親Issue #130 で残る項目）
- 期待挙動2: 同期状態（待ち/中/完了）の視覚表示統一
- 期待挙動3: 新repo表示への自然な収束

これらは UI 設計を伴うため、必要になったら別途子Issueを切って対応する想定。

## 検証
- `npm run check`: 0 errors / 0 warnings
- `npm test`: 11 passed
- `npm run format:check`: clean