### PR TITLE
fix: 検索右半分tintを連続縦帯にして色を薄く

### DIFF
--- a/src/components/layout/SearchBar.svelte
+++ b/src/components/layout/SearchBar.svelte
@@ -343,6 +343,10 @@
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
   }
 
+  .result-row.dual {
+    border-bottom-color: transparent;
+  }
+
   .result-row:last-child {
     border-bottom: none;
   }
@@ -380,13 +384,14 @@
     width: 50%;
     height: 100%;
     border: none;
+    border-radius: 0;
     padding: 0;
     cursor: pointer;
-    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    background: color-mix(in srgb, var(--accent) 4%, transparent);
   }
 
   .result-item-right:hover {
-    background: color-mix(in srgb, var(--accent) 20%, transparent);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
   }
 
   .result-item-left:hover {


### PR DESCRIPTION
検索結果の右半分ペイン tint について以下を調整。

- dual ペイン時は行間の border-bottom を透明化し、tint が横線で分断されず縦1本の直線状に見えるよう修正
- tint 濃度を accent 10% → 4%、hover を 20% → 10% に緩和
- result-item-right に border-radius: 0 を明示

Refs #141