### PR TITLE
chore: #142 breadcrumb world 追従の診断ログを仕込む

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -120,6 +120,13 @@
     document.title = settings.value.toolName
   })
 
+  // [#142] leftWorld / rightWorld 変化を単独で観測（paneState 反映とのタイムラグ確認用）
+  $effect(() => {
+    const lw = leftWorld.value
+    const rw = rightWorld.value
+    console.debug('[#142] world store changed', { leftWorld: lw, rightWorld: rw })
+  })
+
   // paneState をリアクティブに更新
   $effect(() => {
     paneStateStore.value = {

--- a/src/components/layout/PaneView.svelte
+++ b/src/components/layout/PaneView.svelte
@@ -114,6 +114,11 @@
   // ペインのワールドに応じてノート・リーフストアを切り替え
   let paneWorld = $derived(pane === 'left' ? paneState.value.leftWorld : paneState.value.rightWorld)
   let isArchiveWorld = $derived(paneWorld === 'archive')
+
+  // [#142] PaneView に届いた paneWorld の変化を確認（Breadcrumbs に currentWorld として流れる値）
+  $effect(() => {
+    console.debug('[#142] PaneView paneWorld', { pane, paneWorld })
+  })
   let activeNotes = $derived(isArchiveWorld ? archiveNotes.value : notes.value)
   let activeLeaves = $derived(isArchiveWorld ? archiveLeaves.value : leaves.value)
   let activeRootNotes = $derived(

--- a/src/lib/actions/move.ts
+++ b/src/lib/actions/move.ts
@@ -358,8 +358,25 @@ export async function moveLeafToWorld(
 ): Promise<void> {
   const $_ = get(_)
 
+  // [#142] エントリ時の状態を記録（パンくずが world 切替に追従しない問題の診断用）
+  console.debug('[#142] moveLeafToWorld entry', {
+    leafId: leaf.id,
+    leafTitle: leaf.title,
+    targetWorld,
+    pane,
+    leftWorld: leftWorld.value,
+    rightWorld: rightWorld.value,
+    leftLeafId: leftLeaf.value?.id ?? null,
+    rightLeafId: rightLeaf.value?.id ?? null,
+    leftNoteId: leftNote.value?.id ?? null,
+    rightNoteId: rightNote.value?.id ?? null,
+  })
+
   // Pull/Push中またはアーカイブロード中は移動を禁止
-  if (isPulling.value || isPushing.value || appState.isArchiveLoading) return
+  if (isPulling.value || isPushing.value || appState.isArchiveLoading) {
+    console.debug('[#142] moveLeafToWorld blocked (syncing)')
+    return
+  }
 
   // アーカイブへの移動時、アーカイブがロードされていない場合は先にPull
   // Pull後のデータを保持（$archiveNotesはリアクティブ更新が遅れる可能性があるため）
@@ -574,6 +591,20 @@ export async function moveLeafToWorld(
     const paneWorld = paneToCheck === 'left' ? leftWorld.value : rightWorld.value
     const leafMatches = currentLeaf?.id === leaf.id
     const noteMatches = paneWorld === sourceWorld && currentNote?.id === sourceNote.id
+    // [#142] 追従判定の入出力を記録
+    console.debug('[#142] followPane decision', {
+      paneToCheck,
+      paneWorld,
+      sourceWorld,
+      currentLeafId: currentLeaf?.id ?? null,
+      currentNoteId: currentNote?.id ?? null,
+      sourceNoteId: sourceNote.id,
+      leafMatches,
+      noteMatches,
+      willFollow: leafMatches || noteMatches,
+      targetWorld,
+      resolvedTargetNoteId: resolvedTargetNote.id,
+    })
     if (!leafMatches && !noteMatches) return
     if (paneToCheck === 'left') {
       leftNote.value = resolvedTargetNote
@@ -586,6 +617,12 @@ export async function moveLeafToWorld(
       rightView.value = leafMatches ? rightView.value : 'note'
       rightWorld.value = targetWorld
     }
+    // [#142] 書き込み後の world 値を確認
+    console.debug('[#142] followPane after write', {
+      paneToCheck,
+      leftWorld: leftWorld.value,
+      rightWorld: rightWorld.value,
+    })
   }
   followPane('left')
   followPane('right')


### PR DESCRIPTION
refs #142

## 目的

PR #153 で skeleton 残像は解消したが、**リーフを開いた状態でアーカイブしたときパンくず先頭のホームアイコンが Archive アイコンに切り替わらない** 現象が残存。静的コード読解では破綻点を特定できなかったため、デプロイして DevTools console で実行時の値を追跡する。

## ログポイント（すべて `[#142]` プレフィックス）

- `moveLeafToWorld()` エントリ: pane/leaf/世界/現在の leaf/note id
- `followPane` 判定: leafMatches/noteMatches/willFollow/targetWorld
- `followPane` 書き込み後: leftWorld/rightWorld の実値
- `App.svelte` $effect: leftWorld/rightWorld ストア変更を単独観測
- `PaneView.svelte` $effect: paneWorld（Breadcrumbs に渡される currentWorld）の変化

## 運用

1. マージ → Cloudflare Pages 自動デプロイ
2. kako-jun が再現手順を実行（リーフを開く → アーカイブ）
3. DevTools console の `[#142]` 行をコピー → Issue #142 に貼る
4. 原因特定後、ログ削除 PR を出して修正と同時に撤去

## 検証

- `npm run check` pass
- `npm run format:check` pass