### PR TITLE
fix: IndexedDB put 時の DataCloneError を修正

### DIFF
--- a/src/lib/data/storage.ts
+++ b/src/lib/data/storage.ts
@@ -792,11 +792,24 @@ function getAllFromStore<T>(db: IDBDatabase, storeName: string): Promise<T[]> {
   })
 }
 
+/**
+ * IndexedDB put に渡す前に Svelte 5 の $state proxy を剥がす。
+ * proxy のまま store.put() に渡すと structuredClone が内部シンボルを
+ * 辿ってしまい DataCloneError: #<Object> could not be cloned が出る。
+ * Note/Leaf/Settings 等の保存データは JSON セーフな素データなので、
+ * JSON ラウンドトリップで安全にプレーン化できる（undefined フィールド
+ * は落ちるがスキーマ上問題なし）。
+ */
+function toPlain<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
 function replaceAllInStore<T extends { id: string }>(
   db: IDBDatabase,
   storeName: string,
   items: T[]
 ): Promise<void> {
+  const plainItems = toPlain(items)
   return new Promise((resolve, reject) => {
     const tx = db.transaction(storeName, 'readwrite')
     const store = tx.objectStore(storeName)
@@ -807,7 +820,7 @@ function replaceAllInStore<T extends { id: string }>(
 
     const clearReq = store.clear()
     clearReq.onsuccess = () => {
-      for (const item of items) {
+      for (const item of plainItems) {
         store.put(item)
       }
     }
@@ -955,8 +968,9 @@ async function putItemRepo<T>(storeName: string, item: T): Promise<void> {
   const db = await getCurrentDb()
   const tx = db.transaction(storeName, 'readwrite')
   const store = tx.objectStore(storeName)
+  const plainItem = toPlain(item)
   await new Promise<void>((resolve, reject) => {
-    const request = store.put(item)
+    const request = store.put(plainItem)
     request.onsuccess = () => resolve()
     request.onerror = () => reject(request.error)
   })
@@ -983,8 +997,9 @@ async function putItemShared<T>(storeName: string, item: T): Promise<void> {
   const db = await openSharedDB()
   const tx = db.transaction(storeName, 'readwrite')
   const store = tx.objectStore(storeName)
+  const plainItem = toPlain(item)
   await new Promise<void>((resolve, reject) => {
-    const request = store.put(item)
+    const request = store.put(plainItem)
     request.onsuccess = () => resolve()
     request.onerror = () => reject(request.error)
   })


### PR DESCRIPTION
## 現象

新規ノートを作ってアーカイブすると DevTools console に大量の
DataCloneError が出て、notes/leaves/archive notes/archive leaves の
IndexedDB 保存が全部失敗する。

```
DataCloneError: Failed to execute 'put' on 'IDBObjectStore':
#<Object> could not be cloned.
```

## 原因

各ストア（notes/leaves/archiveNotes/archiveLeaves）は Svelte 5 の
`$state<T[]>([])` で deep proxy 化されている。その proxy を
`store.put()` に直接渡すと、IndexedDB 内部の structuredClone が
proxy の内部シンボルを辿って DataCloneError を投げる。

## 修正

`src/lib/data/storage.ts` に `toPlain()` ヘルパーを追加し、
全ての put 経路で proxy を素の JSON オブジェクトに剥がしてから書き込む。

- `replaceAllInStore` (notes/leaves/archiveNotes/archiveLeaves 保存)
- `putItemRepo` (per-repo ストア汎用)
- `putItemShared` (共有 DB 汎用)

Note/Leaf/Settings 等の保存データは JSON セーフな平坦構造なので、
JSON ラウンドトリップで情報欠損は発生しない。

## 検証

- npm run check: 0 errors / 0 warnings
- vitest: 38 passed
- prettier: pass

## 緊急度

高。修正前はアーカイブ操作等でデータ保存が静かに失敗し、再起動で
変更が消える恐れがある。