### PR TITLE
chore: #142 診断ログを撤去（DataCloneError 修正で併せて解消済み）

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -120,13 +120,6 @@
     document.title = settings.value.toolName
   })
 
-  // [#142] leftWorld / rightWorld 変化を単独で観測（paneState 反映とのタイムラグ確認用）
-  $effect(() => {
-    const lw = leftWorld.value
-    const rw = rightWorld.value
-    console.debug('[#142] world store changed', { leftWorld: lw, rightWorld: rw })
-  })
-
   // paneState をリアクティブに更新
   $effect(() => {
     paneStateStore.value = {

--- a/src/components/layout/PaneView.svelte
+++ b/src/components/layout/PaneView.svelte
@@ -114,11 +114,6 @@
   // ペインのワールドに応じてノート・リーフストアを切り替え
   let paneWorld = $derived(pane === 'left' ? paneState.value.leftWorld : paneState.value.rightWorld)
   let isArchiveWorld = $derived(paneWorld === 'archive')
-
-  // [#142] PaneView に届いた paneWorld の変化を確認（Breadcrumbs に currentWorld として流れる値）
-  $effect(() => {
-    console.debug('[#142] PaneView paneWorld', { pane, paneWorld })
-  })
   let activeNotes = $derived(isArchiveWorld ? archiveNotes.value : notes.value)
   let activeLeaves = $derived(isArchiveWorld ? archiveLeaves.value : leaves.value)
   let activeRootNotes = $derived(

--- a/src/lib/actions/move.ts
+++ b/src/lib/actions/move.ts
@@ -358,25 +358,8 @@ export async function moveLeafToWorld(
 ): Promise<void> {
   const $_ = get(_)
 
-  // [#142] エントリ時の状態を記録（パンくずが world 切替に追従しない問題の診断用）
-  console.debug('[#142] moveLeafToWorld entry', {
-    leafId: leaf.id,
-    leafTitle: leaf.title,
-    targetWorld,
-    pane,
-    leftWorld: leftWorld.value,
-    rightWorld: rightWorld.value,
-    leftLeafId: leftLeaf.value?.id ?? null,
-    rightLeafId: rightLeaf.value?.id ?? null,
-    leftNoteId: leftNote.value?.id ?? null,
-    rightNoteId: rightNote.value?.id ?? null,
-  })
-
   // Pull/Push中またはアーカイブロード中は移動を禁止
-  if (isPulling.value || isPushing.value || appState.isArchiveLoading) {
-    console.debug('[#142] moveLeafToWorld blocked (syncing)')
-    return
-  }
+  if (isPulling.value || isPushing.value || appState.isArchiveLoading) return
 
   // アーカイブへの移動時、アーカイブがロードされていない場合は先にPull
   // Pull後のデータを保持（$archiveNotesはリアクティブ更新が遅れる可能性があるため）
@@ -591,20 +574,6 @@ export async function moveLeafToWorld(
     const paneWorld = paneToCheck === 'left' ? leftWorld.value : rightWorld.value
     const leafMatches = currentLeaf?.id === leaf.id
     const noteMatches = paneWorld === sourceWorld && currentNote?.id === sourceNote.id
-    // [#142] 追従判定の入出力を記録
-    console.debug('[#142] followPane decision', {
-      paneToCheck,
-      paneWorld,
-      sourceWorld,
-      currentLeafId: currentLeaf?.id ?? null,
-      currentNoteId: currentNote?.id ?? null,
-      sourceNoteId: sourceNote.id,
-      leafMatches,
-      noteMatches,
-      willFollow: leafMatches || noteMatches,
-      targetWorld,
-      resolvedTargetNoteId: resolvedTargetNote.id,
-    })
     if (!leafMatches && !noteMatches) return
     if (paneToCheck === 'left') {
       leftNote.value = resolvedTargetNote
@@ -617,12 +586,6 @@ export async function moveLeafToWorld(
       rightView.value = leafMatches ? rightView.value : 'note'
       rightWorld.value = targetWorld
     }
-    // [#142] 書き込み後の world 値を確認
-    console.debug('[#142] followPane after write', {
-      paneToCheck,
-      leftWorld: leftWorld.value,
-      rightWorld: rightWorld.value,
-    })
   }
   followPane('left')
   followPane('right')


### PR DESCRIPTION
closes #142

## 背景

PR #156 で仕込んだ `[#142]` プレフィックスの診断ログを kako-jun に
デプロイ版で再現してもらった結果、以下の happy path が観測された:

```
[#142] moveLeafToWorld entry {leafId, targetWorld: 'archive', pane: 'right', ...}
[#142] followPane decision {paneToCheck: 'right', leafMatches: true, ...}
[#142] followPane after write {rightWorld: 'archive'}
[#142] world store changed {rightWorld: 'archive'}
[#142] PaneView paneWorld {pane: 'right', paneWorld: 'archive'}
```

つまり **PR #157（IndexedDB DataCloneError 修正）で #142 の breadcrumb
問題も同時に解消していた**。

## 根本原因

`$state` proxy を IndexedDB put に渡して `DataCloneError` が throw
→ `await saveArchiveNotes(archiveNotes.value)` / `saveArchiveLeaves`
で moveLeafToWorld が脱出 → followPane に到達しない → world が
切り替わらない、という連鎖。proxy を toPlain() で剥がしたら全て
正常動作に戻った。

## 変更

役目を終えた診断ログを全撤去。

- src/lib/actions/move.ts: moveLeafToWorld entry / followPane decision / after write
- src/App.svelte: world store changed $effect
- src/components/layout/PaneView.svelte: PaneView paneWorld $effect

## 検証

- npm run check: 0 errors / 0 warnings
- npm run format:check: pass
- grep -rn '\[#142\]' src/: 残存なし