### PR TITLE
fix: #168 IndexedDBキャッシュ復元時にリーフ統計を再計算

### DIFF
--- a/src/lib/app-state.svelte.ts
+++ b/src/lib/app-state.svelte.ts
@@ -821,6 +821,8 @@ export function initApp(deps: InitAppDeps): () => void {
       ): Promise<number> => {
         notes.value = cache.notes
         leaves.value = cache.leaves
+        // #168: pull スキップ経路でホーム右下のリーフ数・文字数が 0 のままに
+        // ならないよう、pull 完了経路と同じ集計をここで通す。
         leafStatsStore.rebuild(cache.leaves, cache.notes)
         if (cache.metadata) {
           metadata.value = cache.metadata

--- a/src/lib/app-state.svelte.ts
+++ b/src/lib/app-state.svelte.ts
@@ -821,6 +821,7 @@ export function initApp(deps: InitAppDeps): () => void {
       ): Promise<number> => {
         notes.value = cache.notes
         leaves.value = cache.leaves
+        leafStatsStore.rebuild(cache.leaves, cache.notes)
         if (cache.metadata) {
           metadata.value = cache.metadata
         }

--- a/src/lib/stores/leaf-stats.test.ts
+++ b/src/lib/stores/leaf-stats.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+
+import type { Leaf, Note } from '../types'
+
+// 他のテスト同様 jsdom を有効にしていないため、storage 系モジュールが
+// トップレベルで参照する localStorage をスタブしてから動的 import する。
+const store = new Map<string, string>()
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => void store.set(k, v),
+  removeItem: (k: string) => void store.delete(k),
+  clear: () => store.clear(),
+  key: (i: number) => Array.from(store.keys())[i] ?? null,
+  get length() {
+    return store.size
+  },
+}
+
+const { leafStatsStore } = await import('./leaf-stats.svelte')
+
+function makeLeaf(id: string, content: string): Leaf {
+  return {
+    id,
+    noteId: 'note-1',
+    title: id,
+    content,
+    order: 0,
+  } as Leaf
+}
+
+const notes: Note[] = [{ id: 'note-1', name: 'Note', parentId: null, order: 0 }]
+
+describe('leafStatsStore.rebuild', () => {
+  beforeEach(() => {
+    leafStatsStore.reset()
+  })
+
+  it('集計が 0 の状態から rebuild するとリーフ数・文字数が反映される（#168 回帰防止）', () => {
+    const leaves = [makeLeaf('a', 'hello'), makeLeaf('b', 'world!!')]
+    leafStatsStore.rebuild(leaves, notes)
+    expect(leafStatsStore.totalLeafCount).toBe(2)
+    expect(leafStatsStore.totalLeafChars).toBe('hello'.length + 'world!!'.length)
+  })
+
+  it('Priority リーフは集計から除外される', () => {
+    const leaves = [makeLeaf('__priority__', 'ignored content'), makeLeaf('a', 'abc')]
+    leafStatsStore.rebuild(leaves, notes)
+    expect(leafStatsStore.totalLeafCount).toBe(1)
+    expect(leafStatsStore.totalLeafChars).toBe(3)
+  })
+
+  it('rebuild は冪等（同じ入力で複数回呼んでも値が安定）', () => {
+    const leaves = [makeLeaf('a', 'abc'), makeLeaf('b', 'de')]
+    leafStatsStore.rebuild(leaves, notes)
+    leafStatsStore.rebuild(leaves, notes)
+    expect(leafStatsStore.totalLeafCount).toBe(2)
+    expect(leafStatsStore.totalLeafChars).toBe(5)
+  })
+})

--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -30,6 +30,7 @@ import {
   scheduleArchiveNotesSave,
   flushPendingSaves,
 } from './auto-save.svelte'
+import { leafStatsStore } from './leaf-stats.svelte'
 
 // ============================================
 // 基本ストア（Home用）
@@ -886,6 +887,7 @@ export async function rehydrateForRepo(repoKey: string): Promise<void> {
       const [loadedNotes, loadedLeaves] = await Promise.all([loadNotes(), loadLeaves()])
       notes.value = loadedNotes
       leaves.value = loadedLeaves
+      leafStatsStore.rebuild(loadedLeaves, loadedNotes)
       // 読み込んだ内容をダーティ判定のベースラインに設定（Pull 成功前と同じ扱い）
       setLastPushedSnapshot(loadedNotes, loadedLeaves, [], [])
       clearAllChanges()

--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -887,6 +887,8 @@ export async function rehydrateForRepo(repoKey: string): Promise<void> {
       const [loadedNotes, loadedLeaves] = await Promise.all([loadNotes(), loadLeaves()])
       notes.value = loadedNotes
       leaves.value = loadedLeaves
+      // #168: リポ切替直後はキャッシュからのロードのみで pull が走らない経路もあるため、
+      // ホーム右下の統計が 0 にならないよう明示的に再計算する
       leafStatsStore.rebuild(loadedLeaves, loadedNotes)
       // 読み込んだ内容をダーティ判定のベースラインに設定（Pull 成功前と同じ扱い）
       setLastPushedSnapshot(loadedNotes, loadedLeaves, [], [])


### PR DESCRIPTION
## 関連 Issue
closes #168

## 症状
起動時にIndexedDBキャッシュからリーフを復元してpullをスキップする経路で、ホーム右下のリーフ数・文字数が 0 のままになっていた。

## 原因
`applyPersistedStartupCache()` が `notes.value` / `leaves.value` を反映するだけで、`leafStatsStore.rebuild()` を呼んでいなかった。pull 完了経路（`actions/git.ts` の `appActions.rebuildLeafStats`）にしか統計再計算が紐づいていなかった。

## 修正
`applyPersistedStartupCache()` 内で `leafStatsStore.rebuild(cache.leaves, cache.notes)` を呼ぶようにした。これでスキップ経路（#158）・Pullキャンセル経路の両方で統計が更新される。