### PR TITLE
fix: #170 非Vimモードでエディタ入力時にカーソルが先頭に飛ぶ問題

### DIFF
--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -14,6 +14,7 @@
     shouldSuppressMobileScrollIntoView,
   } from '../../lib/editor/mobile-cursor-scroll'
   import { getLastPushedContent, dirtyLeafIds } from '../../lib/stores'
+  import { clampSelectionRanges } from '../../lib/editor/clamp-selection'
 
   interface Props {
     content: string
@@ -72,6 +73,7 @@
   // 動的インポート用の変数
   let EditorState: any
   let EditorView: any
+  let EditorSelection: any
   let StateEffect: any
   let StateField: any
   let keymap: any
@@ -247,7 +249,7 @@
   // CodeMirrorモジュールを動的ロード
   async function loadCodeMirror() {
     const [
-      { EditorState: ES, StateEffect: SE, StateField: SF },
+      { EditorState: ES, StateEffect: SE, StateField: SF, EditorSelection: ESel },
       {
         EditorView: EV,
         keymap: km,
@@ -279,6 +281,7 @@
 
     EditorState = ES
     EditorView = EV
+    EditorSelection = ESel
     StateEffect = SE
     StateField = SF
     keymap = km
@@ -724,13 +727,17 @@
     // カーソルを doc 先頭にリセットする。非Vim モードで自分の入力が
     // 親→子で echo され updateEditorContent に到達したケースで、
     // 1文字打つたびにカーソルが (0,0) へ飛ぶ問題を防ぐため、
-    // 既存の selection を新しい doc 長にクランプして保持する。
+    // 既存の全 selection range を新しい doc 長にクランプして保持する
+    // （マルチカーソルや Vim ビジュアル選択も含む）。
     const prevSelection = editorView.state.selection
-    const newLength = newContent.length
-    const clampedRanges = prevSelection.ranges.map((range: { anchor: number; head: number }) => ({
-      anchor: Math.min(range.anchor, newLength),
-      head: Math.min(range.head, newLength),
-    }))
+    const clamped = clampSelectionRanges(prevSelection.ranges, newContent.length)
+    const nextSelection =
+      clamped.length > 0
+        ? EditorSelection.create(
+            clamped.map((r) => EditorSelection.range(r.anchor, r.head)),
+            prevSelection.mainIndex
+          )
+        : EditorSelection.single(0)
 
     // スクロール位置を保持するため、setState()ではなくdispatch()で差分更新する
     // setState()はエディタ状態全体を置き換えるため、スクロール位置がリセットされてしまう
@@ -740,10 +747,7 @@
         to: currentContent.length,
         insert: newContent,
       },
-      selection: {
-        anchor: clampedRanges[0]?.anchor ?? 0,
-        head: clampedRanges[0]?.head ?? 0,
-      },
+      selection: nextSelection,
     })
     // 注意: isDirtyはリセットしない（Push成功時のみリセットされる）
   }

--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -720,6 +720,18 @@
     const currentContent = editorView.state.doc.toString()
     if (currentContent === newContent) return
 
+    // #170: full replace 時に selection を渡さないと CodeMirror が
+    // カーソルを doc 先頭にリセットする。非Vim モードで自分の入力が
+    // 親→子で echo され updateEditorContent に到達したケースで、
+    // 1文字打つたびにカーソルが (0,0) へ飛ぶ問題を防ぐため、
+    // 既存の selection を新しい doc 長にクランプして保持する。
+    const prevSelection = editorView.state.selection
+    const newLength = newContent.length
+    const clampedRanges = prevSelection.ranges.map((range: { anchor: number; head: number }) => ({
+      anchor: Math.min(range.anchor, newLength),
+      head: Math.min(range.head, newLength),
+    }))
+
     // スクロール位置を保持するため、setState()ではなくdispatch()で差分更新する
     // setState()はエディタ状態全体を置き換えるため、スクロール位置がリセットされてしまう
     editorView.dispatch({
@@ -727,6 +739,10 @@
         from: 0,
         to: currentContent.length,
         insert: newContent,
+      },
+      selection: {
+        anchor: clampedRanges[0]?.anchor ?? 0,
+        head: clampedRanges[0]?.head ?? 0,
       },
     })
     // 注意: isDirtyはリセットしない（Push成功時のみリセットされる）

--- a/src/lib/editor/clamp-selection.test.ts
+++ b/src/lib/editor/clamp-selection.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { clampSelectionRanges } from './clamp-selection'
+
+describe('clampSelectionRanges (#170)', () => {
+  it('既存の単一カーソル位置を保持する', () => {
+    const result = clampSelectionRanges([{ anchor: 5, head: 5 }], 10)
+    expect(result).toEqual([{ anchor: 5, head: 5 }])
+  })
+
+  it('doc 短縮時に範囲外のカーソルを末尾にクランプする', () => {
+    const result = clampSelectionRanges([{ anchor: 20, head: 20 }], 10)
+    expect(result).toEqual([{ anchor: 10, head: 10 }])
+  })
+
+  it('マルチカーソルの全 range を保持する', () => {
+    const result = clampSelectionRanges(
+      [
+        { anchor: 0, head: 0 },
+        { anchor: 3, head: 7 },
+        { anchor: 12, head: 12 },
+      ],
+      10
+    )
+    expect(result).toEqual([
+      { anchor: 0, head: 0 },
+      { anchor: 3, head: 7 },
+      { anchor: 10, head: 10 },
+    ])
+  })
+
+  it('負の anchor/head を 0 にクランプする', () => {
+    const result = clampSelectionRanges([{ anchor: -5, head: -1 }], 10)
+    expect(result).toEqual([{ anchor: 0, head: 0 }])
+  })
+
+  it('空の ranges 入力で空配列を返す', () => {
+    expect(clampSelectionRanges([], 10)).toEqual([])
+  })
+})

--- a/src/lib/editor/clamp-selection.ts
+++ b/src/lib/editor/clamp-selection.ts
@@ -1,0 +1,22 @@
+/**
+ * #170: full doc replace 時にカーソル位置を保持するためのユーティリティ。
+ *
+ * CodeMirror 6 の dispatch に selection を渡さない場合、カーソルは
+ * doc 先頭にリセットされる。doc を全置換するときも既存の selection を
+ * 引き継げるように、各 range を新しい doc 長にクランプして返す。
+ */
+
+export interface SelectionRangeLike {
+  anchor: number
+  head: number
+}
+
+export function clampSelectionRanges(
+  ranges: readonly SelectionRangeLike[],
+  newLength: number
+): SelectionRangeLike[] {
+  return ranges.map((range) => ({
+    anchor: Math.min(Math.max(range.anchor, 0), newLength),
+    head: Math.min(Math.max(range.head, 0), newLength),
+  }))
+}


### PR DESCRIPTION
## 関連 Issue
closes #170

## 症状
PC で Vim モードを OFF にしてエディタに入力すると、1文字打つごとにカーソルが 1行目1文字目に飛び、既存行に続けて入力できない。

## 原因
`MarkdownEditor.svelte` の `updateEditorContent()` が full doc replace を `dispatch` で行う際、`selection` を指定していなかった。CodeMirror 6 は selection を渡さない transaction に対してデフォルトでカーソルを doc 先頭（位置0）にリセットする。

非Vim モードでは、ユーザーの入力 → `onChange` → 親の `leaf.content` 更新 → `$effect`（line 770）が `content` prop の変化を検知 → `updateEditorContent` 呼び出し、という echo 経路に入るタイミングがあり、そこで cursor が飛ばされていた。

Vim モードでは `vim()` 拡張が独自に selection を持ったまま transaction を発行するため発生しない。Android では IME composition 中は早期 return されるため発生しない。

## 修正
`updateEditorContent()` で dispatch する際に、現在の `state.selection.ranges` を新しい doc 長にクランプして `selection` フィールドに渡すようにした。