### PR TITLE
fix: #172 Android で既存行のダーティマーカーが追従しない問題を修正

### DIFF
--- a/src/lib/editor/dirty-lines.ts
+++ b/src/lib/editor/dirty-lines.ts
@@ -187,11 +187,22 @@ export function createDirtyLineExtension(
   const extension: Extension = [
     dirtyLinesField,
     dirtyLineGutter,
-    // ドキュメント変更時にデバウンス付きで更新
+    // ドキュメント変更時にデバウンス付きで更新。
+    // composition 中の dispatch は IME を確定させてしまう（#136）ため抑止する。
     EditorView.updateListener.of((update) => {
       if (update.docChanged && !update.view.composing) {
         debouncedUpdate(update.view)
       }
+    }),
+    // #172: composition 終了時にもダーティ判定を再計算する。
+    // 上のガードで composition 中は全てスキップされるため、composition が終わった
+    // タイミングで明示的に更新しないと、Gboard 等で既存行のダーティマーカーが
+    // 反映されず、次の docChanged（改行など）まで持ち越されて既存行＋新規行が
+    // まとめてダーティ化されるように見える。
+    EditorView.domEventHandlers({
+      compositionend: (_event, view) => {
+        debouncedUpdate(view)
+      },
     }),
   ]
 

--- a/src/lib/editor/dirty-lines.ts
+++ b/src/lib/editor/dirty-lines.ts
@@ -170,8 +170,12 @@ export function createDirtyLineExtension(
       clearTimeout(debounceTimer)
     }
     debounceTimer = setTimeout(() => {
-      updateDirtyLines(view)
       debounceTimer = null
+      // #172 + #136: タイマー満了時に新しい composition が始まっていた場合、
+      // ここで dispatch すると IME を確定させてしまうのでスキップする。
+      // 次の docChanged または compositionend で再スケジュールされる。
+      if (view.composing) return
+      updateDirtyLines(view)
     }, debounceMs)
   }
 


### PR DESCRIPTION
## 関連 Issue
closes #172

## 症状
Android（Gboard）で既存行に文字を打ってもダーティマーカーが付かず、改行を打ったタイミングで初めて既存行＋新規行がまとめてダーティ化されて見える。PC では発生しない。

## 原因
`src/lib/editor/dirty-lines.ts` の updateListener は `!update.view.composing` でガードされている。これは #136（日本語IME中に dispatch すると composition がキャンセルされて1文字確定）を直すための必要なガード。

ただし Gboard は英数字入力でも composition 主体で動くため、composition 中の docChanged が全てスキップされ、composition 終了後の次の docChanged（改行など）まで dirty 判定が持ち越されてしまう。

## 修正
`compositionend` の DOM ハンドラを dirty-lines 拡張に追加し、composition 終了直後に `debouncedUpdate` を呼ぶ。dispatch は composition 終了後に実行されるため #136 のような IME 干渉は起きない。