### PR TITLE
fix: #177 段落内に複数の [N] マーカーがあるとき行ごとに priority を分割する

### DIFF
--- a/src/lib/utils/priority.test.ts
+++ b/src/lib/utils/priority.test.ts
@@ -103,6 +103,16 @@ describe('extractPriorityItems (#177 リストの各項目を独立した priori
     expect(items[1].content).toBe('段落B')
   })
 
+  it('境界マーカー + 中間マーカーが混在する段落は line-level で全行抽出', () => {
+    const leaf = makeLeaf('[1] first\nmiddle [2]\nlast')
+    const items = extractPriorityItems(leaf, 'note', 'note/Test', 0)
+    expect(items).toHaveLength(2)
+    expect(items[0].priority).toBe(1)
+    expect(items[0].content).toBe('first')
+    expect(items[1].priority).toBe(2)
+    expect(items[1].content).toBe('middle')
+  })
+
   it('マーカーがなければ何も抽出しない', () => {
     const leaf = makeLeaf('これは普通のテキスト\n何もマーカーなし')
     expect(extractPriorityItems(leaf, 'note', 'note/Test', 0)).toEqual([])

--- a/src/lib/utils/priority.test.ts
+++ b/src/lib/utils/priority.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Leaf } from '../types'
+
+// jsdom を有効化していないため、storage 系がトップレベルで参照する
+// localStorage をスタブしてから動的 import する
+const _kvStore = new Map<string, string>()
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => _kvStore.get(k) ?? null,
+  setItem: (k: string, v: string) => void _kvStore.set(k, v),
+  removeItem: (k: string) => void _kvStore.delete(k),
+  clear: () => _kvStore.clear(),
+  key: (i: number) => Array.from(_kvStore.keys())[i] ?? null,
+  get length() {
+    return _kvStore.size
+  },
+}
+
+const { extractLinePriorities, extractParagraphPriority, extractPriorityItems } =
+  await import('./priority')
+
+function makeLeaf(content: string): Leaf {
+  return {
+    id: 'leaf-1',
+    title: 'Test',
+    noteId: 'note-1',
+    content,
+    updatedAt: 0,
+    order: 0,
+  }
+}
+
+describe('extractParagraphPriority', () => {
+  it('先頭行の左端 [N] を段落優先度として返す', () => {
+    expect(extractParagraphPriority('[1] hello\nworld')).toBe(1)
+  })
+
+  it('最終行の右端 [N] を段落優先度として返す', () => {
+    expect(extractParagraphPriority('hello\nworld [2]')).toBe(2)
+  })
+
+  it('境界以外のマーカーは認識しない', () => {
+    expect(extractParagraphPriority('hello\n[3] middle\nworld')).toBeNull()
+  })
+})
+
+describe('extractLinePriorities', () => {
+  it('全位置のマーカー（先頭/中間/最終）を拾う', () => {
+    const result = extractLinePriorities('[1] a\nb [2]\n[3] c')
+    expect(result).toEqual([
+      { lineIndex: 0, priority: 1, lineText: 'a' },
+      { lineIndex: 1, priority: 2, lineText: 'b' },
+      { lineIndex: 2, priority: 3, lineText: 'c' },
+    ])
+  })
+
+  it('マーカーのない行は無視する', () => {
+    const result = extractLinePriorities('plain\n[1] marked\nplain')
+    expect(result).toEqual([{ lineIndex: 1, priority: 1, lineText: 'marked' }])
+  })
+})
+
+describe('extractPriorityItems (#177 リストの各項目を独立した priority に分割する)', () => {
+  it('各リスト項目に [N] が付いていれば項目数ぶん独立した priority になる', () => {
+    const leaf = makeLeaf(
+      '## やらないこと\n' +
+        '- 本を増やしすぎない [1]\n' +
+        '- イディオム本や派生シリーズを全部やろうとしない [1]\n' +
+        '- 発音記号の勉強に時間を使いすぎない [2]'
+    )
+    const items = extractPriorityItems(leaf, 'note', 'note/Test', 0)
+    expect(items).toHaveLength(3)
+    expect(items[0].priority).toBe(1)
+    expect(items[0].content).toBe('- 本を増やしすぎない')
+    expect(items[1].priority).toBe(1)
+    expect(items[1].content).toBe('- イディオム本や派生シリーズを全部やろうとしない')
+    expect(items[2].priority).toBe(2)
+    expect(items[2].content).toBe('- 発音記号の勉強に時間を使いすぎない')
+  })
+
+  it('段落の境界に1個だけマーカーがある場合は段落全体を1項目にする', () => {
+    const leaf = makeLeaf('[1] 大事な話\n続きの行1\n続きの行2')
+    const items = extractPriorityItems(leaf, 'note', 'note/Test', 0)
+    expect(items).toHaveLength(1)
+    expect(items[0].priority).toBe(1)
+    expect(items[0].content).toBe('大事な話\n続きの行1\n続きの行2')
+  })
+
+  it('段落の最終行右端に1個だけマーカーがある場合も段落全体を1項目にする', () => {
+    const leaf = makeLeaf('大事な話\n続きの行1\n続きの行2 [2]')
+    const items = extractPriorityItems(leaf, 'note', 'note/Test', 0)
+    expect(items).toHaveLength(1)
+    expect(items[0].priority).toBe(2)
+  })
+
+  it('段落間（空行で区切られた2段落）は別々に処理する', () => {
+    const leaf = makeLeaf('[1] 段落A\n\n[2] 段落B')
+    const items = extractPriorityItems(leaf, 'note', 'note/Test', 0)
+    expect(items).toHaveLength(2)
+    expect(items[0].priority).toBe(1)
+    expect(items[0].content).toBe('段落A')
+    expect(items[1].priority).toBe(2)
+    expect(items[1].content).toBe('段落B')
+  })
+
+  it('マーカーがなければ何も抽出しない', () => {
+    const leaf = makeLeaf('これは普通のテキスト\n何もマーカーなし')
+    expect(extractPriorityItems(leaf, 'note', 'note/Test', 0)).toEqual([])
+  })
+})

--- a/src/lib/utils/priority.ts
+++ b/src/lib/utils/priority.ts
@@ -68,12 +68,10 @@ export function extractParagraphPriority(paragraph: string): number | null {
  * 行単位で引用する優先度を検出する
  *
  * 抽出条件（行単位で引用）:
- * - 先頭行の右端が [n] で終わる
- * - 最後行の左端が [n] で始まる
- * - 中間行の左端が [n] で始まる、または右端が [n] で終わる
- *
- * ※ 段落全体引用（先頭行左端、最後行右端）は extractParagraphPriority で処理
- * ※ 同じ行に複数マーカーがある場合は最初に見つかったものだけ抽出
+ * - 行の左端が [n] で始まる、または右端が [n] で終わる場合、その行を1項目として抽出
+ * - 段落の境界（先頭行左端 / 最後行右端）も含めて全位置を拾う
+ *   （paragraph-level として扱うかは呼び出し側 extractPriorityItems で判定）
+ * - 同じ行に複数マーカーがある場合は最初に見つかったものだけ抽出
  *
  * @param paragraph 段落テキスト
  * @returns 行番号（0始まり）と優先度のペアの配列
@@ -88,58 +86,26 @@ export function extractLinePriorities(
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
-    const isFirstLine = i === 0
-    const isLastLine = i === lines.length - 1
 
-    // 行の左端が [n] で始まる場合（先頭行の左端は段落全体引用なので除外）
-    if (!isFirstLine) {
-      const startMatch = line.match(/^\[(\d+)\] /)
-      if (startMatch) {
-        results.push({
-          lineIndex: i,
-          priority: parseInt(startMatch[1], 10),
-          lineText: line.replace(/^\[(\d+)\] /, ''),
-        })
-        continue
-      }
+    // 行の左端が [n] で始まる場合
+    const startMatch = line.match(/^\[(\d+)\] /)
+    if (startMatch) {
+      results.push({
+        lineIndex: i,
+        priority: parseInt(startMatch[1], 10),
+        lineText: line.replace(/^\[(\d+)\] /, ''),
+      })
+      continue
     }
 
-    // 行の右端が [n] で終わる場合（最後行の右端は段落全体引用なので除外）
-    if (!isLastLine) {
-      const endMatch = line.match(/ \[(\d+)\]$/)
-      if (endMatch) {
-        results.push({
-          lineIndex: i,
-          priority: parseInt(endMatch[1], 10),
-          lineText: line.replace(/ \[(\d+)\]$/, ''),
-        })
-        continue
-      }
-    }
-
-    // 先頭行の右端、最後行の左端もチェック
-    if (isFirstLine) {
-      const endMatch = line.match(/ \[(\d+)\]$/)
-      if (endMatch) {
-        results.push({
-          lineIndex: i,
-          priority: parseInt(endMatch[1], 10),
-          lineText: line.replace(/ \[(\d+)\]$/, ''),
-        })
-        continue
-      }
-    }
-
-    if (isLastLine) {
-      const startMatch = line.match(/^\[(\d+)\] /)
-      if (startMatch) {
-        results.push({
-          lineIndex: i,
-          priority: parseInt(startMatch[1], 10),
-          lineText: line.replace(/^\[(\d+)\] /, ''),
-        })
-        continue
-      }
+    // 行の右端が [n] で終わる場合
+    const endMatch = line.match(/ \[(\d+)\]$/)
+    if (endMatch) {
+      results.push({
+        lineIndex: i,
+        priority: parseInt(endMatch[1], 10),
+        lineText: line.replace(/ \[(\d+)\]$/, ''),
+      })
     }
   }
 
@@ -234,25 +200,40 @@ export function extractPriorityItems(
     const trimmed = text.trim()
     if (!trimmed) continue
 
-    // 1. 段落全体を引用するケースをチェック
-    const paragraphPriority = extractParagraphPriority(trimmed)
-    if (paragraphPriority !== null) {
-      items.push({
-        priority: paragraphPriority,
-        content: removeAllPriorityMarkers(trimmed),
-        leafId: leaf.id,
-        leafTitle: leaf.title,
-        noteId: leaf.noteId,
-        noteName,
-        path,
-        line,
-        displayOrder,
-      })
-      continue
+    // まず段落内の全マーカー行を列挙する（境界含む）
+    const linePriorities = extractLinePriorities(trimmed)
+
+    // #177: 段落全体を1項目として引用するのは「マーカー付き行が1行だけで、
+    // かつそのマーカーが段落の境界（先頭行左端 or 最後行右端）にある」ケースに限定する。
+    // 複数行にマーカーがある場合（例: リストで各項目に [N] を付けた）は、
+    // 行ごとに独立した priority 項目として抽出する。
+    const paragraphLines = trimmed.split('\n')
+    const lastLineIndex = paragraphLines.length - 1
+    const isParagraphBoundaryMarker =
+      linePriorities.length === 1 &&
+      ((linePriorities[0].lineIndex === 0 && /^\[(\d+)\] /.test(paragraphLines[0])) ||
+        (linePriorities[0].lineIndex === lastLineIndex &&
+          / \[(\d+)\]$/.test(paragraphLines[lastLineIndex])))
+
+    if (isParagraphBoundaryMarker) {
+      const paragraphPriority = extractParagraphPriority(trimmed)
+      if (paragraphPriority !== null) {
+        items.push({
+          priority: paragraphPriority,
+          content: removeAllPriorityMarkers(trimmed),
+          leafId: leaf.id,
+          leafTitle: leaf.title,
+          noteId: leaf.noteId,
+          noteName,
+          path,
+          line,
+          displayOrder,
+        })
+        continue
+      }
     }
 
-    // 2. 行単位で引用するケースをチェック
-    const linePriorities = extractLinePriorities(trimmed)
+    // 行単位で抽出
     for (const { lineIndex, priority, lineText } of linePriorities) {
       items.push({
         priority,


### PR DESCRIPTION
## 関連 Issue
closes #177

## 症状
リストの各項目に `[1]` `[1]` `[2]` のように個別に priority マーカーを付けても、Priority リーフでは項目が分割されず、最初に検出された priority のもとに3行まとめて1項目化されていた。

## 原因
`extractParagraphPriority` は段落の境界（先頭行左端 or 最終行右端）に `[N]` があれば段落全体を1項目として扱う仕様。リストでも最終項目の行末に ` [N]` が付くため、境界条件に偶然マッチして段落全体引用モードに入ってしまっていた。

## 修正
- `extractLinePriorities` を境界含めた全位置のマーカーを拾うように単純化
- `extractPriorityItems` の判定を「段落内のマーカー付き行が **1行だけ** で、かつそのマーカーが境界にある」ときのみ paragraph-level、それ以外は line-level に変更
- 単一マーカー（複数行の段落 + 境界に1個）の従来挙動は維持
- `priority.test.ts` を新規追加し、リスト分割・段落単一マーカー・段落間処理・空ケースをカバー