### PR TITLE
fix: #175 ダーティ行番号を doc 変更に追従して再マッピング

### DIFF
--- a/docs/development/ui/dirty-line-marker.md
+++ b/docs/development/ui/dirty-line-marker.md
@@ -120,7 +120,10 @@ const dirtyLinesField = StateField.define<Set<number>>({
     for (const effect of tr.effects) {
       if (effect.is(setDirtyLines)) return effect.value
     }
-    return value
+    // #175: doc 変更で line 番号がずれるのを純関数経由で再マッピングする。
+    // 挿入・削除で行が前後にずれた瞬間に、マーカーが視覚的に違う行へ
+    // 移動して見えるのを防ぐ（debouncedUpdate が走るまでのズレ対策）。
+    return remapDirtyLinesThroughChanges(value, tr)
   },
 })
 

--- a/src/lib/editor/dirty-lines-mapping.test.ts
+++ b/src/lib/editor/dirty-lines-mapping.test.ts
@@ -1,13 +1,14 @@
 /**
- * #175: dirtyLinesField が doc 変更を経由して line 番号を再マッピングする挙動の回帰防止テスト。
+ * #175: dirtyLinesField が doc 変更を経由して line 番号を再マッピングする
+ * 純関数 remapDirtyLinesThroughChanges の回帰防止テスト。
  *
- * dirtyLinesField 本体は createDirtyLineExtension 内部にあり、@codemirror/view の
- * GutterMarker / gutter（DOM 依存）も使うため直接 import できない。
- * ここでは StateField の update ロジック相当を再現したテストヘルパーで、
- * 同じマッピングロジックを @codemirror/state のみで動かして検証する。
+ * StateField 本体は @codemirror/view（DOM 依存）に紐づくため、
+ * 純関数だけを抜き出してテストする。本番コードと同じ関数を import するため
+ * test/本体間の drift は起きない。
  */
 import { describe, expect, it } from 'vitest'
 import { EditorState, StateEffect, StateField, Text } from '@codemirror/state'
+import { remapDirtyLinesThroughChanges } from './dirty-lines'
 
 const setDirtyLines = StateEffect.define<Set<number>>()
 
@@ -15,24 +16,9 @@ const dirtyLinesField = StateField.define<Set<number>>({
   create: () => new Set(),
   update(value, tr) {
     for (const effect of tr.effects) {
-      if (effect.is(setDirtyLines)) {
-        return effect.value
-      }
+      if (effect.is(setDirtyLines)) return effect.value
     }
-    if (tr.docChanged && value.size > 0) {
-      const oldDoc = tr.startState.doc
-      const newDoc = tr.state.doc
-      const next = new Set<number>()
-      for (const lineNo of value) {
-        if (lineNo < 1 || lineNo > oldDoc.lines) continue
-        const oldLineFrom = oldDoc.line(lineNo).from
-        const newPos = tr.changes.mapPos(oldLineFrom, 1)
-        if (newPos < 0 || newPos > newDoc.length) continue
-        next.add(newDoc.lineAt(newPos).number)
-      }
-      return next
-    }
-    return value
+    return remapDirtyLinesThroughChanges(value, tr)
   },
 })
 
@@ -41,18 +27,13 @@ function createState(doc: string) {
   return EditorState.create({ doc: text, extensions: [dirtyLinesField] })
 }
 
-describe('dirtyLinesField doc-change mapping (#175)', () => {
+describe('remapDirtyLinesThroughChanges (#175)', () => {
   it('上に行を挿入したらダーティ行番号が下にシフトする', () => {
     let state = createState('a\nb\nc\nd\ne')
-    state = state.update({
-      effects: setDirtyLines.of(new Set([4, 5])), // d, e がダーティ
-    }).state
+    state = state.update({ effects: setDirtyLines.of(new Set([4, 5])) }).state
     expect(state.field(dirtyLinesField)).toEqual(new Set([4, 5]))
 
-    // 先頭に2行挿入
-    state = state.update({
-      changes: { from: 0, insert: 'X\nY\n' },
-    }).state
+    state = state.update({ changes: { from: 0, insert: 'X\nY\n' } }).state
     expect(state.field(dirtyLinesField)).toEqual(new Set([6, 7]))
   })
 
@@ -60,23 +41,15 @@ describe('dirtyLinesField doc-change mapping (#175)', () => {
     let state = createState('a\nb\nc\nd\ne')
     state = state.update({ effects: setDirtyLines.of(new Set([4, 5])) }).state
 
-    // 先頭2行（"a\nb\n"）を削除
-    state = state.update({
-      changes: { from: 0, to: 4 },
-    }).state
+    state = state.update({ changes: { from: 0, to: 4 } }).state
     expect(state.field(dirtyLinesField)).toEqual(new Set([2, 3]))
   })
 
-  it('ダーティ行そのものを削除した場合は Set から消える', () => {
+  it('ダーティ行そのものを削除しても範囲外の値が残らない', () => {
     let state = createState('a\nb\nc\nd\ne')
     state = state.update({ effects: setDirtyLines.of(new Set([3])) }).state
 
-    // line 3 ("c\n") を完全削除
-    state = state.update({
-      changes: { from: 4, to: 6 },
-    }).state
-    // 削除位置が前の行末にマップされて line 2 になる、または Set に残る場合あり。
-    // 重要なのは「現存しない line 6 などに残らない」こと。
+    state = state.update({ changes: { from: 4, to: 6 } }).state
     const result = state.field(dirtyLinesField)
     for (const lineNo of result) {
       expect(lineNo).toBeLessThanOrEqual(state.doc.lines)
@@ -90,11 +63,10 @@ describe('dirtyLinesField doc-change mapping (#175)', () => {
     expect(state.field(dirtyLinesField).size).toBe(0)
   })
 
-  it('setDirtyLines effect が来たら docChange より優先される', () => {
+  it('setDirtyLines effect は docChange より優先される', () => {
     let state = createState('a\nb\nc')
     state = state.update({ effects: setDirtyLines.of(new Set([1, 2])) }).state
 
-    // 同一 transaction で docChange + effect の両方
     state = state.update({
       changes: { from: 0, insert: 'X\n' },
       effects: setDirtyLines.of(new Set([5])),

--- a/src/lib/editor/dirty-lines-mapping.test.ts
+++ b/src/lib/editor/dirty-lines-mapping.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #175: dirtyLinesField が doc 変更を経由して line 番号を再マッピングする挙動の回帰防止テスト。
+ *
+ * dirtyLinesField 本体は createDirtyLineExtension 内部にあり、@codemirror/view の
+ * GutterMarker / gutter（DOM 依存）も使うため直接 import できない。
+ * ここでは StateField の update ロジック相当を再現したテストヘルパーで、
+ * 同じマッピングロジックを @codemirror/state のみで動かして検証する。
+ */
+import { describe, expect, it } from 'vitest'
+import { EditorState, StateEffect, StateField, Text } from '@codemirror/state'
+
+const setDirtyLines = StateEffect.define<Set<number>>()
+
+const dirtyLinesField = StateField.define<Set<number>>({
+  create: () => new Set(),
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setDirtyLines)) {
+        return effect.value
+      }
+    }
+    if (tr.docChanged && value.size > 0) {
+      const oldDoc = tr.startState.doc
+      const newDoc = tr.state.doc
+      const next = new Set<number>()
+      for (const lineNo of value) {
+        if (lineNo < 1 || lineNo > oldDoc.lines) continue
+        const oldLineFrom = oldDoc.line(lineNo).from
+        const newPos = tr.changes.mapPos(oldLineFrom, 1)
+        if (newPos < 0 || newPos > newDoc.length) continue
+        next.add(newDoc.lineAt(newPos).number)
+      }
+      return next
+    }
+    return value
+  },
+})
+
+function createState(doc: string) {
+  const text = Text.of(doc.split('\n'))
+  return EditorState.create({ doc: text, extensions: [dirtyLinesField] })
+}
+
+describe('dirtyLinesField doc-change mapping (#175)', () => {
+  it('上に行を挿入したらダーティ行番号が下にシフトする', () => {
+    let state = createState('a\nb\nc\nd\ne')
+    state = state.update({
+      effects: setDirtyLines.of(new Set([4, 5])), // d, e がダーティ
+    }).state
+    expect(state.field(dirtyLinesField)).toEqual(new Set([4, 5]))
+
+    // 先頭に2行挿入
+    state = state.update({
+      changes: { from: 0, insert: 'X\nY\n' },
+    }).state
+    expect(state.field(dirtyLinesField)).toEqual(new Set([6, 7]))
+  })
+
+  it('上の行を削除したらダーティ行番号が上にシフトする', () => {
+    let state = createState('a\nb\nc\nd\ne')
+    state = state.update({ effects: setDirtyLines.of(new Set([4, 5])) }).state
+
+    // 先頭2行（"a\nb\n"）を削除
+    state = state.update({
+      changes: { from: 0, to: 4 },
+    }).state
+    expect(state.field(dirtyLinesField)).toEqual(new Set([2, 3]))
+  })
+
+  it('ダーティ行そのものを削除した場合は Set から消える', () => {
+    let state = createState('a\nb\nc\nd\ne')
+    state = state.update({ effects: setDirtyLines.of(new Set([3])) }).state
+
+    // line 3 ("c\n") を完全削除
+    state = state.update({
+      changes: { from: 4, to: 6 },
+    }).state
+    // 削除位置が前の行末にマップされて line 2 になる、または Set に残る場合あり。
+    // 重要なのは「現存しない line 6 などに残らない」こと。
+    const result = state.field(dirtyLinesField)
+    for (const lineNo of result) {
+      expect(lineNo).toBeLessThanOrEqual(state.doc.lines)
+      expect(lineNo).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('docChanged でも dirty Set が空なら何もしない（高速パス）', () => {
+    let state = createState('a\nb\nc')
+    state = state.update({ changes: { from: 0, insert: 'X\n' } }).state
+    expect(state.field(dirtyLinesField).size).toBe(0)
+  })
+
+  it('setDirtyLines effect が来たら docChange より優先される', () => {
+    let state = createState('a\nb\nc')
+    state = state.update({ effects: setDirtyLines.of(new Set([1, 2])) }).state
+
+    // 同一 transaction で docChange + effect の両方
+    state = state.update({
+      changes: { from: 0, insert: 'X\n' },
+      effects: setDirtyLines.of(new Set([5])),
+    }).state
+    expect(state.field(dirtyLinesField)).toEqual(new Set([5]))
+  })
+})

--- a/src/lib/editor/dirty-lines.ts
+++ b/src/lib/editor/dirty-lines.ts
@@ -120,6 +120,23 @@ export function createDirtyLineExtension(
           return effect.value
         }
       }
+      // #175: doc が変更された transaction では、保持している line 番号を
+      // 新しい doc に合わせて再マッピングする。これをしないと挿入・削除で
+      // 行が前後にずれた瞬間にマーカーが視覚的に違う行へ移動して見える
+      // （次の debouncedUpdate が走るまで 200ms 程度ズレが残る）。
+      if (tr.docChanged && value.size > 0) {
+        const oldDoc = tr.startState.doc
+        const newDoc = tr.state.doc
+        const next = new Set<number>()
+        for (const lineNo of value) {
+          if (lineNo < 1 || lineNo > oldDoc.lines) continue
+          const oldLineFrom = oldDoc.line(lineNo).from
+          const newPos = tr.changes.mapPos(oldLineFrom, 1)
+          if (newPos < 0 || newPos > newDoc.length) continue
+          next.add(newDoc.lineAt(newPos).number)
+        }
+        return next
+      }
       return value
     },
   })

--- a/src/lib/editor/dirty-lines.ts
+++ b/src/lib/editor/dirty-lines.ts
@@ -3,7 +3,26 @@
  * 最後にPushした状態から変更された行にマーカーを表示する
  */
 
-import type { Extension } from '@codemirror/state'
+import type { Extension, Transaction } from '@codemirror/state'
+
+/**
+ * #175: dirty line 番号を doc 変更に追従して再マッピングする純関数。
+ * StateField.update から呼ぶとともに、回帰防止テストからも同じロジックを使う。
+ */
+export function remapDirtyLinesThroughChanges(value: Set<number>, tr: Transaction): Set<number> {
+  if (!tr.docChanged || value.size === 0) return value
+  const oldDoc = tr.startState.doc
+  const newDoc = tr.state.doc
+  const next = new Set<number>()
+  for (const lineNo of value) {
+    if (lineNo < 1 || lineNo > oldDoc.lines) continue
+    const oldLineFrom = oldDoc.line(lineNo).from
+    const newPos = tr.changes.mapPos(oldLineFrom, 1)
+    if (newPos < 0 || newPos > newDoc.length) continue
+    next.add(newDoc.lineAt(newPos).number)
+  }
+  return next
+}
 
 /**
  * LCS (Longest Common Subsequence) を計算
@@ -120,24 +139,8 @@ export function createDirtyLineExtension(
           return effect.value
         }
       }
-      // #175: doc が変更された transaction では、保持している line 番号を
-      // 新しい doc に合わせて再マッピングする。これをしないと挿入・削除で
-      // 行が前後にずれた瞬間にマーカーが視覚的に違う行へ移動して見える
-      // （次の debouncedUpdate が走るまで 200ms 程度ズレが残る）。
-      if (tr.docChanged && value.size > 0) {
-        const oldDoc = tr.startState.doc
-        const newDoc = tr.state.doc
-        const next = new Set<number>()
-        for (const lineNo of value) {
-          if (lineNo < 1 || lineNo > oldDoc.lines) continue
-          const oldLineFrom = oldDoc.line(lineNo).from
-          const newPos = tr.changes.mapPos(oldLineFrom, 1)
-          if (newPos < 0 || newPos > newDoc.length) continue
-          next.add(newDoc.lineAt(newPos).number)
-        }
-        return next
-      }
-      return value
+      // #175: doc 変更で line 番号がずれるのを純関数経由で再マッピングする
+      return remapDirtyLinesThroughChanges(value, tr)
     },
   })
 


### PR DESCRIPTION
## 関連 Issue
closes #175

## 症状
編集中に「10行目を打っているのに 2-3 行目にダーティマーカーが付く」など、編集している行と異なる行にマーカーが表示される現象。

## 原因
\`dirtyLinesField\` の \`update()\` は \`setDirtyLines\` effect が来たときだけ Set を入れ替え、\`tr.docChanged\` だけの transaction では古い Set をそのまま返していた。

そのため、行を挿入・削除して line 番号がずれた瞬間にマーカーが視覚的に違う行へ移動して見える。次の \`debouncedUpdate\`（200ms）が走るまでこのズレが残る。

例: 12, 13 行目がダーティ → 先頭から数行を削除 → 現在の 2, 3 行目が以前の 12, 13 → Set は \`{12, 13}\` のまま → 2, 3 行目には付かず、存在しない 12, 13 行目に判定がぶら下がる（あるいは別の行に視覚的に移って見える）。

## 修正
\`tr.docChanged\` のとき、Set 内の各 line 番号の先頭位置を \`tr.changes.mapPos\` でマッピングし、新しい doc 上の line 番号で Set を再構築する。

- 行そのものが削除されたケースは範囲外の値が入らないようガード
- 空 Set のときは早期 return
- \`setDirtyLines\` effect が同 transaction にあれば従来通り effect 値を採用

## テスト
\`dirty-lines-mapping.test.ts\` を新規追加:
- 上に行挿入で番号が下にシフト
- 上の行削除で番号が上にシフト
- ダーティ行そのものを削除しても範囲内に収まる
- 空 Set の高速パス
- \`setDirtyLines\` effect が docChange より優先される