### PR TITLE
fix: #176 vim/theme/罫線/cursorTrail 切替時にカーソル位置が先頭に飛ぶ

### DIFF
--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -780,9 +780,27 @@
         pendingVimScrollFrame = null
       }
       clearPendingMobileCursorScroll()
+      // #176: 再初期化前に selection を退避し、新しい view に復元する。
+      // 新規 EditorState は selection が暗黙的に (0,0) になるため、これを
+      // しないと vim/theme/罫線/cursorTrail を切り替えた直後に updateEditorContent が
+      // 呼ばれた際、PR #171 のクランプ経路で (0,0) を保持してしまい入力位置が
+      // 先頭に張り付く症状が出る。
+      const prevSelection = editorView.state.selection
       editorView.destroy()
       editorView = null
       initializeEditor()
+      if (editorView && prevSelection && EditorSelection) {
+        const _editorView: any = editorView
+        const clamped = clampSelectionRanges(prevSelection.ranges, _editorView.state.doc.length)
+        if (clamped.length > 0) {
+          _editorView.dispatch({
+            selection: EditorSelection.create(
+              clamped.map((r) => EditorSelection.range(r.anchor, r.head)),
+              prevSelection.mainIndex
+            ),
+          })
+        }
+      }
     }
   })
 

--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -783,17 +783,16 @@
       // #176: 再初期化前に selection を退避し、新しい view に復元する。
       // 新規 EditorState は selection が暗黙的に (0,0) になるため、これを
       // しないと vim/theme/罫線/cursorTrail を切り替えた直後に updateEditorContent が
-      // 呼ばれた際、PR #171 のクランプ経路で (0,0) を保持してしまい入力位置が
-      // 先頭に張り付く症状が出る。
+      // 呼ばれた際、PR #171 のクランプ経路で (0,0) を保持してしまい、入力1文字
+      // ごとにカーソルが先頭行に張り付く症状（#170 と同型）が再発する。
       const prevSelection = editorView.state.selection
       editorView.destroy()
       editorView = null
       initializeEditor()
       if (editorView && prevSelection && EditorSelection) {
-        const _editorView: any = editorView
-        const clamped = clampSelectionRanges(prevSelection.ranges, _editorView.state.doc.length)
+        const clamped = clampSelectionRanges(prevSelection.ranges, editorView.state.doc.length)
         if (clamped.length > 0) {
-          _editorView.dispatch({
+          editorView.dispatch({
             selection: EditorSelection.create(
               clamped.map((r) => EditorSelection.range(r.anchor, r.head)),
               prevSelection.mainIndex


### PR DESCRIPTION
## 関連 Issue
closes #176

## 症状
通常モードで起動 → Vim モードに切替 → 通常モードに戻す、の流れの後（あるいは theme・罫線・cursorTrail 切替後）に、カーソルが先頭行 (0,0) に張り付き続ける症状。

## 原因
`MarkdownEditor.svelte:756` の `\$effect`（deps: `[theme, vimMode, linedMode, cursorTrailEnabled]`）が editorView を destroy → `initializeEditor()` で新しい view を作るが、新 EditorState の selection は暗黙的に (0,0) になる。

直後に `updateEditorContent` が呼ばれると、PR #171 で導入したクランプ経路が「現在の selection (0,0) を保持」してしまい、入力位置が先頭に張り付く。

## 修正
destroy の直前に selection を退避し、`initializeEditor()` 完了後に新 doc 長でクランプして `dispatch` で復元する。`clampSelectionRanges` + `EditorSelection.create` を使い、マルチカーソル・mainIndex も維持。

vim 経由・theme/罫線/cursorTrail 切替経由のいずれでも対応。

## 関連
- #170 / PR #171 元のカーソル飛び修正
- #176 vim 切替後の症状再発（本PR）