### PR TITLE
chore: #183 診断ログ（一時）— vim insert モード解除の原因特定

### DIFF
--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -596,6 +596,13 @@
           // スペースキーでペイン切り替え
           Vim.defineAction('switchPane', function () {
             const paneId = getCurrentPane()
+            // [#183-diag] switchPane が想定外に呼ばれている疑いがあるためトレース
+            console.warn('[#183-diag] switchPane FIRED', {
+              paneId,
+              activeElement: document.activeElement?.tagName,
+              activeClass: (document.activeElement as HTMLElement)?.className,
+              stack: new Error().stack,
+            })
             const callbacks = paneId ? window.editorCallbacks?.[paneId] : null
             if (callbacks?.onSwitchPane) {
               callbacks.onSwitchPane()
@@ -721,6 +728,27 @@
     // DOM要素にペイン情報をマーク（Vimコマンドで参照するため）
     editorView.dom.dataset.pane = pane
 
+    // [#183-diag] vim-mode-change を購読してモード遷移を全部ログ出力
+    if (vimMode && Vim) {
+      import('@replit/codemirror-vim')
+        .then(({ getCM }) => {
+          const cm = getCM(editorView)
+          if (cm && typeof (cm as any).on === 'function') {
+            ;(cm as any).on('vim-mode-change', (e: any) => {
+              console.warn('[#183-diag] vim-mode-change', {
+                pane,
+                mode: e?.mode,
+                subMode: e?.subMode,
+                stack: new Error().stack,
+              })
+            })
+          }
+        })
+        .catch((err) => {
+          console.warn('[#183-diag] failed to attach vim-mode-change listener', err)
+        })
+    }
+
     // 初回のダーティライン更新
     if (updateDirtyLinesFn && editorView) {
       updateDirtyLinesFn(editorView)
@@ -754,6 +782,15 @@
           )
         : EditorSelection.single(0)
 
+    // [#183-diag] content prop echo 経路の dispatch
+    console.warn('[#183-diag] updateEditorContent DISPATCH', {
+      pane,
+      vimMode,
+      curLen: currentContent.length,
+      newLen: newContent.length,
+      selection: JSON.stringify(prevSelection.main),
+    })
+
     // スクロール位置を保持するため、setState()ではなくdispatch()で差分更新する
     // setState()はエディタ状態全体を置き換えるため、スクロール位置がリセットされてしまう
     editorView.dispatch({
@@ -773,6 +810,15 @@
     const _deps = [theme, vimMode, linedMode, cursorTrailEnabled]
     if (!editorView || _deps.length === 0) return
     if (editorView) {
+      // [#183-diag] 再 init 開始
+      console.warn('[#183-diag] editor reinit START', {
+        pane,
+        vimMode,
+        theme,
+        linedMode,
+        cursorTrailEnabled,
+        prevSelection: JSON.stringify(editorView.state.selection.main),
+      })
       flushPendingCompositionChange(editorView)
       isComposing = false
       // dirtyLeafIdsストアの購読解除
@@ -805,6 +851,13 @@
       editorView.destroy()
       editorView = null
       initializeEditor(prevSelection)
+      // [#183-diag] 再 init 完了
+      console.warn('[#183-diag] editor reinit DONE', {
+        pane,
+        vimMode,
+        editorViewExists: !!editorView,
+        newSelection: editorView ? JSON.stringify((editorView as any).state.selection.main) : null,
+      })
     }
   })
 


### PR DESCRIPTION
## 目的
Issue #183 の原因を特定するため、一時的に診断ログを仕込む。マージ → デプロイ → kako-jun が再現 → コンソールログを共有 → 原因特定 → ログ撤去 PR、の流れ。

## 仕込んだログ（すべて \`[#183-diag]\` プレフィクス・\`console.warn\`）

| ログ | タイミング |
|---|---|
| editor reinit START | line 736 \$effect が destroy 開始した瞬間 |
| editor reinit DONE | initializeEditor 完了後の selection |
| updateEditorContent DISPATCH | content prop echo 経由で full replace dispatch が走ったタイミング |
| switchPane FIRED | switchPane アクションが呼ばれた瞬間（activeElement + stack trace） |
| vim-mode-change | vim プラグインのモード遷移（normal ↔ insert ↔ visual）すべて、stack trace 付き |

## 検証手順
1. デプロイ反映を確認
2. PC ブラウザで devtools 開いた状態で再現
3. コンソールに出る \`[#183-diag]\` ログを全コピーで送ってください

## 注意
- 撤去用 PR を別途立てます。一時的な変更です