### PR TITLE
fix: #187 leftLeaf/rightLeaf を field mutation で更新（vim insert 抜本対策）

### DIFF
--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -772,10 +772,16 @@
     // 各 prop を読み取ることでリアクティブ追跡に登録する
     const _deps = [theme, vimMode, linedMode, cursorTrailEnabled]
     if (!editorView || _deps.length === 0) return
-    // #183: destroy + initializeEditor は untrack で囲み、initializeEditor 内部の
-    // reactive 読み取り（content / leafId / dirtyLeafIds.value 等）が暗黙にこの
-    // effect の dep に追加されるのを防ぐ。これがないと 1 文字打つたびに content
-    // などが bump して reinit が走り、vim 拡張の insert state が消える。
+    // #183/#187: destroy + initializeEditor は untrack で囲み、initializeEditor 内部の
+    // reactive 読み取り（content / leafId / dirtyLeafIds.value 等）が暗黙にこの effect の
+    // dep に追加されるのを防ぐ。これがないと 1 文字打つたびに content が bump して reinit が
+    // 走り、vim 拡張の insert state が消える。
+    //
+    // #187 で leftLeaf/leaves[i] を field mutation 化したことで leafId の無駄 bump は止まった
+    // が、content は新しい EditorState を seed するために initializeEditor 内で読む必要があり、
+    // 同時に keystroke 毎の bump は legitimate（外部から content prop が変わったときに
+    // updateEditorContent で反映するための signal）。よって untrack は構造上必須であり、
+    // 撤去できない。
     untrack(() => {
       if (!editorView) return
       flushPendingCompositionChange(editorView)

--- a/src/lib/actions/crud.ts
+++ b/src/lib/actions/crud.ts
@@ -27,6 +27,7 @@ import {
   getDialogPositionForPane,
   applyLeafFieldUpdate,
   applyNoteFieldUpdate,
+  mutateArchiveLeavesItem,
 } from '../stores'
 import {
   createNote as createNoteLib,
@@ -498,19 +499,11 @@ export async function updateLeafContent(
       }
     }
 
-    const updatedLeaf: Leaf = {
-      ...targetLeaf,
-      title: newTitle,
-      content,
-      updatedAt: Date.now(),
-    }
-    updateArchiveLeaves(allLeaves.map((l) => (l.id === leafId ? updatedLeaf : l)))
-
-    applyLeafFieldUpdate(leafId, {
-      title: updatedLeaf.title,
-      content: updatedLeaf.content,
-      updatedAt: updatedLeaf.updatedAt,
-    })
+    // #187 Phase 2: in-place mutation で archive leaves[i] を更新（outer array source bump 回避）。
+    // applyLeafFieldUpdate は leftLeaf/rightLeaf が leaves[i] と別プロキシだった場合の安全網。
+    const partial = { title: newTitle, content, updatedAt: Date.now() }
+    mutateArchiveLeavesItem(leafId, partial)
+    applyLeafFieldUpdate(leafId, partial)
     if (titleChanged) appActions.refreshBreadcrumbs()
     return
   }
@@ -551,19 +544,14 @@ export function updateLeafBadge(
     const targetLeaf = allLeaves.find((l) => l.id === leafId)
     if (!targetLeaf) return
 
-    const updatedLeaf: Leaf = {
-      ...targetLeaf,
+    // #187 Phase 2: in-place mutation
+    const partial = {
       badgeIcon: normalizeBadgeValue(badgeIcon),
       badgeColor: normalizeBadgeValue(badgeColor),
       updatedAt: Date.now(),
     }
-    updateArchiveLeaves(allLeaves.map((l) => (l.id === leafId ? updatedLeaf : l)))
-
-    applyLeafFieldUpdate(leafId, {
-      badgeIcon: updatedLeaf.badgeIcon,
-      badgeColor: updatedLeaf.badgeColor,
-      updatedAt: updatedLeaf.updatedAt,
-    })
+    mutateArchiveLeavesItem(leafId, partial)
+    applyLeafFieldUpdate(leafId, partial)
     return
   }
 

--- a/src/lib/actions/crud.ts
+++ b/src/lib/actions/crud.ts
@@ -96,11 +96,14 @@ export async function saveEditBreadcrumb(
 
     const updatedNote = updatedNotes.find((f) => f.id === actualId)
     if (updatedNote) {
+      // #187: 同じ id のノートが既に左右ペインに居る場合、object 全体を再代入すると
+      // $state の outer source が bump し、id 等の不変フィールドの読者まで再実行される。
+      // 変わったフィールド（name）だけを mutate して field-level signal だけ bump する。
       if (leftNote.value?.id === actualId) {
-        leftNote.value = updatedNote
+        leftNote.value.name = updatedNote.name
       }
       if (isRight && rightNote.value?.id === actualId) {
-        rightNote.value = updatedNote
+        rightNote.value!.name = updatedNote.name
       }
     }
     if (!paneNotes.some((f) => f.id === leftNote.value?.id)) {
@@ -144,11 +147,16 @@ export async function saveEditBreadcrumb(
 
     const updatedLeaf = updatedLeaves.find((n) => n.id === actualId)
     if (updatedLeaf) {
+      // #187: field mutation で同じ id のリーフを更新（理由は上の updatedNote コメント参照）
       if (leftLeaf.value?.id === actualId) {
-        leftLeaf.value = updatedLeaf
+        leftLeaf.value.title = updatedLeaf.title
+        leftLeaf.value.content = updatedLeaf.content
+        leftLeaf.value.updatedAt = updatedLeaf.updatedAt
       }
       if (isRight && rightLeaf.value?.id === actualId) {
-        rightLeaf.value = updatedLeaf
+        rightLeaf.value!.title = updatedLeaf.title
+        rightLeaf.value!.content = updatedLeaf.content
+        rightLeaf.value!.updatedAt = updatedLeaf.updatedAt
       }
     }
     if (!paneLeaves.some((n) => n.id === leftLeaf.value?.id)) {
@@ -494,8 +502,18 @@ export async function updateLeafContent(
     }
     updateArchiveLeaves(allLeaves.map((l) => (l.id === leafId ? updatedLeaf : l)))
 
-    if (leftLeaf.value?.id === leafId) leftLeaf.value = updatedLeaf
-    if (rightLeaf.value?.id === leafId) rightLeaf.value = updatedLeaf
+    // #187: field mutation で同じ id のリーフを更新。object 再代入だと $state outer source が bump し、
+    // 不変な id を読む reactive 読者（MarkdownEditor の reinit $effect 等）まで再実行されてしまう。
+    if (leftLeaf.value?.id === leafId) {
+      leftLeaf.value.title = updatedLeaf.title
+      leftLeaf.value.content = updatedLeaf.content
+      leftLeaf.value.updatedAt = updatedLeaf.updatedAt
+    }
+    if (rightLeaf.value?.id === leafId) {
+      rightLeaf.value.title = updatedLeaf.title
+      rightLeaf.value.content = updatedLeaf.content
+      rightLeaf.value.updatedAt = updatedLeaf.updatedAt
+    }
     if (titleChanged) appActions.refreshBreadcrumbs()
     return
   }
@@ -511,8 +529,17 @@ export async function updateLeafContent(
     },
   })
   if (result.updatedLeaf) {
-    if (leftLeaf.value?.id === leafId) leftLeaf.value = result.updatedLeaf
-    if (rightLeaf.value?.id === leafId) rightLeaf.value = result.updatedLeaf
+    // #187: field mutation（理由は archive 経路と同じ）
+    if (leftLeaf.value?.id === leafId) {
+      leftLeaf.value.title = result.updatedLeaf.title
+      leftLeaf.value.content = result.updatedLeaf.content
+      leftLeaf.value.updatedAt = result.updatedLeaf.updatedAt
+    }
+    if (rightLeaf.value?.id === leafId) {
+      rightLeaf.value.title = result.updatedLeaf.title
+      rightLeaf.value.content = result.updatedLeaf.content
+      rightLeaf.value.updatedAt = result.updatedLeaf.updatedAt
+    }
     if (result.titleChanged) appActions.refreshBreadcrumbs()
   }
 }
@@ -541,16 +568,34 @@ export function updateLeafBadge(
     }
     updateArchiveLeaves(allLeaves.map((l) => (l.id === leafId ? updatedLeaf : l)))
 
-    if (leftLeaf.value?.id === leafId) leftLeaf.value = updatedLeaf
-    if (rightLeaf.value?.id === leafId) rightLeaf.value = updatedLeaf
+    // #187: field mutation（理由は updateLeafContent のコメント参照）
+    if (leftLeaf.value?.id === leafId) {
+      leftLeaf.value.badgeIcon = updatedLeaf.badgeIcon
+      leftLeaf.value.badgeColor = updatedLeaf.badgeColor
+      leftLeaf.value.updatedAt = updatedLeaf.updatedAt
+    }
+    if (rightLeaf.value?.id === leafId) {
+      rightLeaf.value.badgeIcon = updatedLeaf.badgeIcon
+      rightLeaf.value.badgeColor = updatedLeaf.badgeColor
+      rightLeaf.value.updatedAt = updatedLeaf.updatedAt
+    }
     return
   }
 
   // Home内の場合は既存処理
   const updated = updateLeafBadgeLib(leafId, badgeIcon, badgeColor)
   if (updated) {
-    if (leftLeaf.value?.id === leafId) leftLeaf.value = updated
-    if (rightLeaf.value?.id === leafId) rightLeaf.value = updated
+    // #187: field mutation
+    if (leftLeaf.value?.id === leafId) {
+      leftLeaf.value.badgeIcon = updated.badgeIcon
+      leftLeaf.value.badgeColor = updated.badgeColor
+      leftLeaf.value.updatedAt = updated.updatedAt
+    }
+    if (rightLeaf.value?.id === leafId) {
+      rightLeaf.value.badgeIcon = updated.badgeIcon
+      rightLeaf.value.badgeColor = updated.badgeColor
+      rightLeaf.value.updatedAt = updated.updatedAt
+    }
   }
 }
 

--- a/src/lib/actions/crud.ts
+++ b/src/lib/actions/crud.ts
@@ -25,6 +25,8 @@ import {
   updateNotes,
   updateLeaves,
   getDialogPositionForPane,
+  applyLeafFieldUpdate,
+  applyNoteFieldUpdate,
 } from '../stores'
 import {
   createNote as createNoteLib,
@@ -96,14 +98,16 @@ export async function saveEditBreadcrumb(
 
     const updatedNote = updatedNotes.find((f) => f.id === actualId)
     if (updatedNote) {
-      // #187: 同じ id のノートが既に左右ペインに居る場合、object 全体を再代入すると
-      // $state の outer source が bump し、id 等の不変フィールドの読者まで再実行される。
-      // 変わったフィールド（name）だけを mutate して field-level signal だけ bump する。
-      if (leftNote.value?.id === actualId) {
-        leftNote.value.name = updatedNote.name
+      // #187: object 全体を再代入すると outer source が bump して不変な id の読者まで
+      // 再実行されるため、フィールド単位で mutate する。既存の左右非対称ガード
+      // （右ペイン側 edit 起動時のみ右ペインを更新）はそのまま踏襲する。
+      const $leftNote = leftNote.value
+      const $rightNote = rightNote.value
+      if ($leftNote?.id === actualId) {
+        $leftNote.name = updatedNote.name
       }
-      if (isRight && rightNote.value?.id === actualId) {
-        rightNote.value!.name = updatedNote.name
+      if (isRight && $rightNote?.id === actualId) {
+        $rightNote.name = updatedNote.name
       }
     }
     if (!paneNotes.some((f) => f.id === leftNote.value?.id)) {
@@ -147,17 +151,17 @@ export async function saveEditBreadcrumb(
 
     const updatedLeaf = updatedLeaves.find((n) => n.id === actualId)
     if (updatedLeaf) {
-      // #187: field mutation で同じ id のリーフを更新（理由は上の updatedNote コメント参照）
-      if (leftLeaf.value?.id === actualId) {
-        leftLeaf.value.title = updatedLeaf.title
-        leftLeaf.value.content = updatedLeaf.content
-        leftLeaf.value.updatedAt = updatedLeaf.updatedAt
+      // #187: field mutation で同じ id のリーフを更新（理由は上の updatedNote コメント参照）。
+      // 既存の左右非対称ガード（isRight 時のみ右ペイン更新）を踏襲。
+      const $leftLeaf = leftLeaf.value
+      const $rightLeaf = rightLeaf.value
+      const partial = {
+        title: updatedLeaf.title,
+        content: updatedLeaf.content,
+        updatedAt: updatedLeaf.updatedAt,
       }
-      if (isRight && rightLeaf.value?.id === actualId) {
-        rightLeaf.value!.title = updatedLeaf.title
-        rightLeaf.value!.content = updatedLeaf.content
-        rightLeaf.value!.updatedAt = updatedLeaf.updatedAt
-      }
+      if ($leftLeaf?.id === actualId) Object.assign($leftLeaf, partial)
+      if (isRight && $rightLeaf?.id === actualId) Object.assign($rightLeaf, partial)
     }
     if (!paneLeaves.some((n) => n.id === leftLeaf.value?.id)) {
       leftLeaf.value = null
@@ -502,18 +506,11 @@ export async function updateLeafContent(
     }
     updateArchiveLeaves(allLeaves.map((l) => (l.id === leafId ? updatedLeaf : l)))
 
-    // #187: field mutation で同じ id のリーフを更新。object 再代入だと $state outer source が bump し、
-    // 不変な id を読む reactive 読者（MarkdownEditor の reinit $effect 等）まで再実行されてしまう。
-    if (leftLeaf.value?.id === leafId) {
-      leftLeaf.value.title = updatedLeaf.title
-      leftLeaf.value.content = updatedLeaf.content
-      leftLeaf.value.updatedAt = updatedLeaf.updatedAt
-    }
-    if (rightLeaf.value?.id === leafId) {
-      rightLeaf.value.title = updatedLeaf.title
-      rightLeaf.value.content = updatedLeaf.content
-      rightLeaf.value.updatedAt = updatedLeaf.updatedAt
-    }
+    applyLeafFieldUpdate(leafId, {
+      title: updatedLeaf.title,
+      content: updatedLeaf.content,
+      updatedAt: updatedLeaf.updatedAt,
+    })
     if (titleChanged) appActions.refreshBreadcrumbs()
     return
   }
@@ -529,17 +526,11 @@ export async function updateLeafContent(
     },
   })
   if (result.updatedLeaf) {
-    // #187: field mutation（理由は archive 経路と同じ）
-    if (leftLeaf.value?.id === leafId) {
-      leftLeaf.value.title = result.updatedLeaf.title
-      leftLeaf.value.content = result.updatedLeaf.content
-      leftLeaf.value.updatedAt = result.updatedLeaf.updatedAt
-    }
-    if (rightLeaf.value?.id === leafId) {
-      rightLeaf.value.title = result.updatedLeaf.title
-      rightLeaf.value.content = result.updatedLeaf.content
-      rightLeaf.value.updatedAt = result.updatedLeaf.updatedAt
-    }
+    applyLeafFieldUpdate(leafId, {
+      title: result.updatedLeaf.title,
+      content: result.updatedLeaf.content,
+      updatedAt: result.updatedLeaf.updatedAt,
+    })
     if (result.titleChanged) appActions.refreshBreadcrumbs()
   }
 }
@@ -568,34 +559,22 @@ export function updateLeafBadge(
     }
     updateArchiveLeaves(allLeaves.map((l) => (l.id === leafId ? updatedLeaf : l)))
 
-    // #187: field mutation（理由は updateLeafContent のコメント参照）
-    if (leftLeaf.value?.id === leafId) {
-      leftLeaf.value.badgeIcon = updatedLeaf.badgeIcon
-      leftLeaf.value.badgeColor = updatedLeaf.badgeColor
-      leftLeaf.value.updatedAt = updatedLeaf.updatedAt
-    }
-    if (rightLeaf.value?.id === leafId) {
-      rightLeaf.value.badgeIcon = updatedLeaf.badgeIcon
-      rightLeaf.value.badgeColor = updatedLeaf.badgeColor
-      rightLeaf.value.updatedAt = updatedLeaf.updatedAt
-    }
+    applyLeafFieldUpdate(leafId, {
+      badgeIcon: updatedLeaf.badgeIcon,
+      badgeColor: updatedLeaf.badgeColor,
+      updatedAt: updatedLeaf.updatedAt,
+    })
     return
   }
 
   // Home内の場合は既存処理
   const updated = updateLeafBadgeLib(leafId, badgeIcon, badgeColor)
   if (updated) {
-    // #187: field mutation
-    if (leftLeaf.value?.id === leafId) {
-      leftLeaf.value.badgeIcon = updated.badgeIcon
-      leftLeaf.value.badgeColor = updated.badgeColor
-      leftLeaf.value.updatedAt = updated.updatedAt
-    }
-    if (rightLeaf.value?.id === leafId) {
-      rightLeaf.value.badgeIcon = updated.badgeIcon
-      rightLeaf.value.badgeColor = updated.badgeColor
-      rightLeaf.value.updatedAt = updated.updatedAt
-    }
+    applyLeafFieldUpdate(leafId, {
+      badgeIcon: updated.badgeIcon,
+      badgeColor: updated.badgeColor,
+      updatedAt: updated.updatedAt,
+    })
   }
 }
 

--- a/src/lib/actions/move.ts
+++ b/src/lib/actions/move.ts
@@ -27,6 +27,7 @@ import {
   updateArchiveLeaves,
   archiveLeafStatsStore,
   setArchiveBaseline,
+  applyLeafFieldUpdate,
 } from '../stores'
 import {
   saveNotes,
@@ -637,16 +638,15 @@ export async function moveLeafTo(
     updateArchiveLeaves([...remaining, movedLeaf])
     isStructureDirty.value = true
 
-    const $leftLeaf = leftLeaf.value
-    const $rightLeaf = rightLeaf.value
-    if ($leftLeaf?.id === targetLeaf.id) {
-      leftLeaf.value = movedLeaf
-      leftNote.value = destinationNote
-    }
-    if ($rightLeaf?.id === targetLeaf.id) {
-      rightLeaf.value = movedLeaf
-      rightNote.value = destinationNote
-    }
+    // #187: leaf は同 id（noteId/order/updatedAt のみ変化）→ field mutation。
+    // note は destinationNote へ識別子が変わる切替なので reassignment が正しい。
+    applyLeafFieldUpdate(targetLeaf.id, {
+      noteId: movedLeaf.noteId,
+      order: movedLeaf.order,
+      updatedAt: movedLeaf.updatedAt,
+    })
+    if (leftLeaf.value?.id === targetLeaf.id) leftNote.value = destinationNote
+    if (rightLeaf.value?.id === targetLeaf.id) rightNote.value = destinationNote
     showPushToast($_('toast.moved'), 'success')
     appActions.closeMoveModal()
     return
@@ -655,16 +655,14 @@ export async function moveLeafTo(
   // Home内の場合は既存処理
   const result = moveLeafToLib(targetLeaf, destNoteId, $_)
   if (result.success && result.movedLeaf && result.destNote) {
-    const $leftLeaf = leftLeaf.value
-    const $rightLeaf = rightLeaf.value
-    if ($leftLeaf?.id === targetLeaf.id) {
-      leftLeaf.value = result.movedLeaf
-      leftNote.value = result.destNote
-    }
-    if ($rightLeaf?.id === targetLeaf.id) {
-      rightLeaf.value = result.movedLeaf
-      rightNote.value = result.destNote
-    }
+    // #187: leaf は同 id → field mutation、note は識別子変更 → reassignment（理由は archive 経路と同じ）
+    applyLeafFieldUpdate(targetLeaf.id, {
+      noteId: result.movedLeaf.noteId,
+      order: result.movedLeaf.order,
+      updatedAt: result.movedLeaf.updatedAt,
+    })
+    if (leftLeaf.value?.id === targetLeaf.id) leftNote.value = result.destNote
+    if (rightLeaf.value?.id === targetLeaf.id) rightNote.value = result.destNote
     // スケルトンマップから移動したリーフを削除（noteIdが古いままになるため）
     const leafSkeletonMap = appState.leafSkeletonMap
     if (leafSkeletonMap.has(targetLeaf.id)) {

--- a/src/lib/data/leaves.ts
+++ b/src/lib/data/leaves.ts
@@ -4,7 +4,7 @@
 
 import type { Note, Leaf } from '../types'
 import type { Pane } from '../navigation'
-import { notes, leaves, updateLeaves } from '../stores'
+import { notes, leaves, updateLeaves, mutateLeavesItem } from '../stores'
 import { showAlert, showConfirm, showPushToast } from '../ui'
 // 循環参照回避: utils/index.tsではなく、直接utils.tsからインポート
 import { generateUniqueName, normalizeBadgeValue } from '../utils/utils'
@@ -159,13 +159,14 @@ export function updateLeafContent(options: UpdateLeafContentOptions): {
     }
   }
 
-  // グローバルストアを更新（isDirtyはスナップショット比較で自動検出）
-  const updatedLeaves = allLeaves.map((n) =>
-    n.id === leafId ? { ...n, content, title: newTitle, updatedAt: Date.now() } : n
-  )
-  updateLeaves(updatedLeaves)
+  // #187 Phase 2: in-place mutation で leaves[i] を更新（outer array source の bump を回避）。
+  // 識別子は保持されるため leftLeaf/rightLeaf と leaves[i] が同一プロキシのままになる。
+  const updatedAt = Date.now()
+  mutateLeavesItem(leafId, { content, title: newTitle, updatedAt })
 
-  const updatedLeaf = updatedLeaves.find((n) => n.id === leafId) || null
+  // 戻り値の updatedLeaf は呼び出し元の applyLeafFieldUpdate の安全網と
+  // refreshBreadcrumbs 判定用。leaves.value から取得した同一プロキシを返す。
+  const updatedLeaf = leaves.value.find((n) => n.id === leafId) || null
   return { updatedLeaf, titleChanged }
 }
 
@@ -191,14 +192,14 @@ export function updateLeafBadge(
     return null
   }
 
-  const updatedLeaves = allLeaves.map((n) =>
-    n.id === leafId
-      ? { ...n, badgeIcon: nextIcon, badgeColor: nextColor, updatedAt: Date.now() }
-      : n
-  )
-  updateLeaves(updatedLeaves)
+  // #187 Phase 2: in-place mutation（理由は updateLeafContent 参照）
+  mutateLeavesItem(leafId, {
+    badgeIcon: nextIcon,
+    badgeColor: nextColor,
+    updatedAt: Date.now(),
+  })
 
-  return updatedLeaves.find((l) => l.id === leafId) || null
+  return leaves.value.find((l) => l.id === leafId) || null
 }
 
 /**

--- a/src/lib/stores/leaf-mutators.test.ts
+++ b/src/lib/stores/leaf-mutators.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+
+import type { Leaf, Note } from '../types'
+
+// stores.svelte.ts はトップレベルで storage モジュールを読み、その先で localStorage に
+// 触れるためスタブしてから動的 import する。
+const store = new Map<string, string>()
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => void store.set(k, v),
+  removeItem: (k: string) => void store.delete(k),
+  clear: () => store.clear(),
+  key: (i: number) => Array.from(store.keys())[i] ?? null,
+  get length() {
+    return store.size
+  },
+}
+
+const { leftLeaf, rightLeaf, leftNote, rightNote, applyLeafFieldUpdate, applyNoteFieldUpdate } =
+  await import('./stores.svelte')
+
+function makeLeaf(id: string, overrides: Partial<Leaf> = {}): Leaf {
+  return {
+    id,
+    noteId: 'note-1',
+    title: id,
+    content: 'initial',
+    order: 0,
+    ...overrides,
+  } as Leaf
+}
+
+function makeNote(id: string, overrides: Partial<Note> = {}): Note {
+  return {
+    id,
+    name: id,
+    parentId: null,
+    order: 0,
+    ...overrides,
+  } as Note
+}
+
+describe('applyLeafFieldUpdate (#187 抜本対策)', () => {
+  beforeEach(() => {
+    leftLeaf.value = null
+    rightLeaf.value = null
+  })
+
+  it('同 id のリーフは reference を保ったまま指定フィールドだけが更新される', () => {
+    leftLeaf.value = makeLeaf('a', { content: 'old' })
+    const before = leftLeaf.value
+
+    applyLeafFieldUpdate('a', { content: 'new', updatedAt: 123 })
+
+    const after = leftLeaf.value
+    // outer source を bump させない = $state プロキシの参照は同一
+    expect(Object.is(before, after)).toBe(true)
+    expect(after?.content).toBe('new')
+    expect(after?.updatedAt).toBe(123)
+    // 不変フィールド（id / noteId / title）は触らない
+    expect(after?.id).toBe('a')
+    expect(after?.noteId).toBe('note-1')
+    expect(after?.title).toBe('a')
+  })
+
+  it('id が一致しないリーフは何も変更しない', () => {
+    leftLeaf.value = makeLeaf('a', { content: 'old' })
+    rightLeaf.value = makeLeaf('b', { content: 'old' })
+
+    applyLeafFieldUpdate('z', { content: 'new' })
+
+    expect(leftLeaf.value?.content).toBe('old')
+    expect(rightLeaf.value?.content).toBe('old')
+  })
+
+  it('左右両ペインに同 id のリーフがある場合、両方 mutate する', () => {
+    leftLeaf.value = makeLeaf('a', { content: 'old' })
+    rightLeaf.value = makeLeaf('a', { content: 'old' })
+    const beforeLeft = leftLeaf.value
+    const beforeRight = rightLeaf.value
+
+    applyLeafFieldUpdate('a', { content: 'new' })
+
+    expect(Object.is(beforeLeft, leftLeaf.value)).toBe(true)
+    expect(Object.is(beforeRight, rightLeaf.value)).toBe(true)
+    expect(leftLeaf.value?.content).toBe('new')
+    expect(rightLeaf.value?.content).toBe('new')
+  })
+
+  it('片方のペインだけ id 一致の場合、そちらだけ mutate する', () => {
+    leftLeaf.value = makeLeaf('a', { content: 'old' })
+    rightLeaf.value = makeLeaf('b', { content: 'old' })
+
+    applyLeafFieldUpdate('a', { content: 'new' })
+
+    expect(leftLeaf.value?.content).toBe('new')
+    expect(rightLeaf.value?.content).toBe('old')
+  })
+
+  it('null の場合はクラッシュせずに何もしない', () => {
+    leftLeaf.value = null
+    rightLeaf.value = null
+
+    expect(() => applyLeafFieldUpdate('a', { content: 'new' })).not.toThrow()
+  })
+})
+
+describe('applyNoteFieldUpdate (#187 抜本対策)', () => {
+  beforeEach(() => {
+    leftNote.value = null
+    rightNote.value = null
+  })
+
+  it('同 id のノートは reference を保ったまま指定フィールドだけが更新される', () => {
+    leftNote.value = makeNote('n1', { name: 'old' })
+    const before = leftNote.value
+
+    applyNoteFieldUpdate('n1', { name: 'new' })
+
+    const after = leftNote.value
+    expect(Object.is(before, after)).toBe(true)
+    expect(after?.name).toBe('new')
+    expect(after?.id).toBe('n1')
+  })
+})

--- a/src/lib/stores/leaf-mutators.test.ts
+++ b/src/lib/stores/leaf-mutators.test.ts
@@ -16,8 +16,20 @@ const store = new Map<string, string>()
   },
 }
 
-const { leftLeaf, rightLeaf, leftNote, rightNote, applyLeafFieldUpdate, applyNoteFieldUpdate } =
-  await import('./stores.svelte')
+const {
+  leftLeaf,
+  rightLeaf,
+  leftNote,
+  rightNote,
+  leaves,
+  archiveLeaves,
+  updateLeaves,
+  updateArchiveLeaves,
+  applyLeafFieldUpdate,
+  applyNoteFieldUpdate,
+  mutateLeavesItem,
+  mutateArchiveLeavesItem,
+} = await import('./stores.svelte')
 
 function makeLeaf(id: string, overrides: Partial<Leaf> = {}): Leaf {
   return {
@@ -102,6 +114,57 @@ describe('applyLeafFieldUpdate (#187 抜本対策)', () => {
     rightLeaf.value = null
 
     expect(() => applyLeafFieldUpdate('a', { content: 'new' })).not.toThrow()
+  })
+})
+
+describe('mutateLeavesItem (#187 Phase 2: 配列 in-place mutation)', () => {
+  beforeEach(() => {
+    updateLeaves([])
+    leftLeaf.value = null
+    rightLeaf.value = null
+  })
+
+  it('対象リーフを配列の identity を保ったまま mutate する', () => {
+    updateLeaves([makeLeaf('a', { content: 'old' }), makeLeaf('b', { content: 'old' })])
+    const arrBefore = leaves.value
+    const itemBefore = leaves.value[0]
+
+    const ok = mutateLeavesItem('a', { content: 'new', updatedAt: 42 })
+
+    expect(ok).toBe(true)
+    // 配列自体の identity も保たれる（Phase 2 の核心）
+    expect(Object.is(arrBefore, leaves.value)).toBe(true)
+    // 対象 leaf の identity も保たれる
+    expect(Object.is(itemBefore, leaves.value[0])).toBe(true)
+    expect(leaves.value[0].content).toBe('new')
+    expect(leaves.value[0].updatedAt).toBe(42)
+    expect(leaves.value[1].content).toBe('old')
+  })
+
+  it('id が見つからなければ false を返し、配列に変化なし', () => {
+    updateLeaves([makeLeaf('a', { content: 'old' })])
+
+    const ok = mutateLeavesItem('z', { content: 'new' })
+
+    expect(ok).toBe(false)
+    expect(leaves.value[0].content).toBe('old')
+  })
+})
+
+describe('mutateArchiveLeavesItem (#187 Phase 2)', () => {
+  beforeEach(() => {
+    updateArchiveLeaves([])
+  })
+
+  it('archive 配列も同様に in-place mutation', () => {
+    updateArchiveLeaves([makeLeaf('a', { content: 'old' })])
+    const itemBefore = archiveLeaves.value[0]
+
+    const ok = mutateArchiveLeavesItem('a', { content: 'new' })
+
+    expect(ok).toBe(true)
+    expect(Object.is(itemBefore, archiveLeaves.value[0])).toBe(true)
+    expect(archiveLeaves.value[0].content).toBe('new')
   })
 })
 

--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -663,13 +663,46 @@ export const rightLeaf = {
  * reactive 読者（MarkdownEditor の reinit \$effect 等）まで再実行される。field mutation で
  * field-level signal だけ bump させ、id 等の不変フィールドの読者は再実行されないようにする。
  *
- * leaves.value 配列側は別途 updateLeaves 等で新配列に差し替えられる。OLD object（leftLeaf）と
- * NEW object（leaves[i]）は識別子は別だが値は同期。reference 比較は detectDirtyIds 等いずれの
- * 経路でも行わないため無害。
+ * leaves.value 配列側は mutateLeavesItem / mutateArchiveLeavesItem で同様に in-place mutation
+ * させると、leftLeaf と leaves[i] が同一プロキシのままになり、識別子が完全に保持される。
  */
 export function applyLeafFieldUpdate(leafId: string, partial: Partial<Leaf>): void {
   if (_leftLeaf?.id === leafId) Object.assign(_leftLeaf, partial)
   if (_rightLeaf?.id === leafId) Object.assign(_rightLeaf, partial)
+}
+
+/**
+ * Home の leaves 配列に対し、対象 id のリーフを in-place mutation で更新する。
+ * #187 Phase 2: updateLeaves(newArray) は outer array source を bump させ、leaves を
+ * 反復する全ての reactive reader を再評価させる（1000 リーフ × 1 文字編集 = 大量再評価）。
+ * 在地 mutation なら $state proxy の field-level signal だけが bump し、波及が必要最小限になる。
+ *
+ * scheduleLeavesSave / updateHomeDirtyIds の bookkeeping は updateLeaves と同じく実施する。
+ * detectDirtyIds は値比較ベース、lastPushedLeaves は JSON deep-copy snapshot なので
+ * in-place mutation でも正しく差分検出される。
+ *
+ * 戻り値: 対象が見つかれば true、見つからなければ false。
+ */
+export function mutateLeavesItem(leafId: string, partial: Partial<Leaf>): boolean {
+  const target = _leaves.find((l) => l.id === leafId)
+  if (!target) return false
+  Object.assign(target, partial)
+  scheduleLeavesSave()
+  updateHomeDirtyIds(_notes, _leaves)
+  return true
+}
+
+/**
+ * Archive の leaves 配列に対し、対象 id のリーフを in-place mutation で更新する。
+ * 詳細は mutateLeavesItem のコメント参照。
+ */
+export function mutateArchiveLeavesItem(leafId: string, partial: Partial<Leaf>): boolean {
+  const target = _archiveLeaves.find((l) => l.id === leafId)
+  if (!target) return false
+  Object.assign(target, partial)
+  scheduleArchiveLeavesSave()
+  updateArchiveDirtyIds(_archiveNotes, _archiveLeaves)
+  return true
 }
 
 /**

--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -657,6 +657,30 @@ export const rightLeaf = {
   },
 }
 
+/**
+ * 左右ペインに表示中の同 id のリーフに対し、指定フィールドだけを mutate する。
+ * #187: object 全体を再代入すると $state の outer source が bump し、不変な id を読む
+ * reactive 読者（MarkdownEditor の reinit \$effect 等）まで再実行される。field mutation で
+ * field-level signal だけ bump させ、id 等の不変フィールドの読者は再実行されないようにする。
+ *
+ * leaves.value 配列側は別途 updateLeaves 等で新配列に差し替えられる。OLD object（leftLeaf）と
+ * NEW object（leaves[i]）は識別子は別だが値は同期。reference 比較は detectDirtyIds 等いずれの
+ * 経路でも行わないため無害。
+ */
+export function applyLeafFieldUpdate(leafId: string, partial: Partial<Leaf>): void {
+  if (_leftLeaf?.id === leafId) Object.assign(_leftLeaf, partial)
+  if (_rightLeaf?.id === leafId) Object.assign(_rightLeaf, partial)
+}
+
+/**
+ * 左右ペインに表示中の同 id のノートに対し、指定フィールドだけを mutate する。
+ * 詳細は applyLeafFieldUpdate のコメント参照。
+ */
+export function applyNoteFieldUpdate(noteId: string, partial: Partial<Note>): void {
+  if (_leftNote?.id === noteId) Object.assign(_leftNote, partial)
+  if (_rightNote?.id === noteId) Object.assign(_rightNote, partial)
+}
+
 let _leftView = $state<View>('home')
 export const leftView = {
   get value() {


### PR DESCRIPTION
## 関連 Issue

closes #187

## 背景（#183 untrack 対症療法の根本原因）

Svelte 5 の `$state(obj)` は outer source（S0）と各フィールドの signal（Fid, Fcontent, …）を持つ。`_leftLeaf = newObj` のような object 再代入は **S0 を bump** するため、`leftLeaf.value.id` のような不変フィールドを読んでいる reactive 読者まで再実行される。

これが #183 の現象の根因:

- 1 文字編集 → `crud.ts` で `leftLeaf.value = { ...targetLeaf, content, ... }`
- → outer source bump → `storeLeaf = $derived(leftLeaf.value)` → `currentLeaf` → `<MarkdownEditor leafId={leaf.id} content={leaf.content} />` の伝播
- → `MarkdownEditor` の reinit `$effect` が暗黙に `content` / `leafId` を dep に拾い再発火
- → editor destroy → CodeMirror Vim 拡張の insert state 消失 → normal mode に戻る

#183 PR は reinit `$effect` の本体を `untrack(() => …)` で囲んで暗黙 dep を切ったが、これは **症状を止めただけ**。「id が無駄に bump する」現象自体は残っていた。

## 変更内容

### Phase 1: leftLeaf/rightLeaf の field mutation 化

同じ id のリーフ／ノートを更新する経路で、object 全体の再代入を field mutation に置き換えた。outer source は不変、変わったフィールドの signal だけが bump する。

| 関数 | 経路 | 変わるフィールド |
|---|---|---|
| `saveEditBreadcrumb` (note rename) | - | `name` |
| `saveEditBreadcrumb` (leaf rename) | - | `title`, `content`, `updatedAt` |
| `updateLeafContent` | archive / home | `title`, `content`, `updatedAt` |
| `updateLeafBadge` | archive / home | `badgeIcon`, `badgeColor`, `updatedAt` |
| `moveLeafTo` (leaf 側) | archive / home | `noteId`, `order`, `updatedAt` |

ヘルパー: `applyLeafFieldUpdate(leafId, partial)`, `applyNoteFieldUpdate(noteId, partial)` を `stores.svelte.ts` に集約。

### Phase 2a: leaves.value 配列の in-place mutation 化

これまで `updateLeaves(allLeaves.map(...))` で 1 文字編集ごとに **新配列＋新リーフオブジェクト** を生成していたため、leaves outer array source と leaves[i] 識別子が両方 bump し、leaves を反復する全ての reactive reader を毎回再評価させていた（1000 リーフあれば 1 文字打つたびに 1000 件再評価）。

`mutateLeavesItem(leafId, partial)` / `mutateArchiveLeavesItem(leafId, partial)` で在地 mutation に切替:
- leaves outer array source は不変
- leaves[i] proxy 識別子も不変
- 変わったフィールドの signal だけが bump
- leftLeaf/rightLeaf と leaves[i] が**同一プロキシのまま**になり、識別子が完全保持

bookkeeping（`scheduleLeavesSave` / `updateHomeDirtyIds`）はヘルパー内で実施。`detectDirtyIds` は値比較、`lastPushedLeaves` は JSON deep-copy snapshot なので差分検出は壊れない。

### Phase 2b: untrack 撤去検証 → 撤去不可（保持）

reinit `$effect` は新 `EditorState` を seed するために `initializeEditor` 内で `content` を読む必要がある。`content` は keystroke 毎に bump するのが legitimate（外部から content prop が変わったとき `updateEditorContent` で反映するための signal）。よって untrack なしだと content tracking で reinit が毎キー発火し vim insert が消える。Phase 1/2 で leafId 経路は塞がれたが content 経路は残るため **untrack は構造上必須**。MarkdownEditor のコメントを「対症療法」→「構造上必須」と更新。

### スコープ外の経路

リーフ／ノート切替（`pane-navigation` の `leftLeaf.value = anotherLeaf`）は識別子が変わるので再代入が正しい — 触らない。

## 安全性確認

- スナップショット（`JSON.parse(JSON.stringify(...))`）= deep copy → reference 同一性に依存しない
- `detectDirtyIds` = 値比較ベース
- `{#key currentLeaf.id}` は同 id 維持なので EditorView 再生成は起きない
- IndexedDB シリアライズは `leaves.value` の値を見るので無関係

## Test

- `npm run lint` ✅ pass
- `npx vitest run` ✅ **74/74 pass**（leaf-mutators.test.ts に 9 ケース新規追加）

## Test plan（実機）

- [ ] vim mode で 1 文字打って insert モードが維持されることを Android 実機で確認
- [ ] 通常エディタで 1 文字編集後にエディタが再生成されない（フォーカスとカーソル位置が維持される）
- [ ] リーフ切替時は EditorView が再生成される（`{#key currentLeaf.id}` の挙動）
- [ ] パンくずから note rename / leaf rename → 表示が更新される
- [ ] バッジ更新 → 表示が更新される
- [ ] リーフを別ノートに移動 → 移動先ノートの一覧に現れる
- [ ] #186 と整合（push 後ダーティ表示が正しく消える）