### PR TITLE
fix: #197 検索結果クリック時にキーワード行へ直接ジャンプする

### DIFF
--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -29,6 +29,7 @@
     cursorTrailEnabled?: boolean
     leafId?: string
     pane: Pane
+    initialLine?: number
     onChange: (newContent: string) => void
     onPush?: (() => void) | null
     onClose?: (() => void) | null
@@ -44,6 +45,7 @@
     cursorTrailEnabled = true,
     leafId = '',
     pane,
+    initialLine = 0,
     onChange,
     onPush = null,
     onClose = null,
@@ -840,6 +842,10 @@
     await loadCodeMirror()
     initializeEditor()
     registerEditorFlusher(pane, flushForRegistry)
+    // 検索結果クリック時など、マウント直後に特定行へジャンプする場合
+    if (initialLine > 0) {
+      scrollToLine(initialLine)
+    }
   })
 
   onDestroy(() => {

--- a/src/components/editor/MarkdownEditor.svelte
+++ b/src/components/editor/MarkdownEditor.svelte
@@ -18,6 +18,8 @@
     dirtyLeafIds,
     registerEditorFlusher,
     unregisterEditorFlusher,
+    leftInitialLine,
+    rightInitialLine,
   } from '../../lib/stores'
   import { clampSelectionRanges } from '../../lib/editor/clamp-selection'
 
@@ -842,9 +844,15 @@
     await loadCodeMirror()
     initializeEditor()
     registerEditorFlusher(pane, flushForRegistry)
-    // 検索結果クリック時など、マウント直後に特定行へジャンプする場合
+    // 検索結果クリック時など、マウント直後に特定行へジャンプする場合。
+    // 使用後はストアをリセットして、後続の再マウント時に誤ジャンプしないようにする。
     if (initialLine > 0) {
       scrollToLine(initialLine)
+      if (pane === 'left') {
+        leftInitialLine.value = 0
+      } else {
+        rightInitialLine.value = 0
+      }
     }
   })
 

--- a/src/components/layout/PaneView.svelte
+++ b/src/components/layout/PaneView.svelte
@@ -31,6 +31,8 @@
     leftView,
     rightView,
     focusedPane,
+    leftInitialLine,
+    rightInitialLine,
   } from '../../lib/stores'
 
   // ビューコンポーネント
@@ -241,6 +243,7 @@
         linedMode={settings.value.linedMode ?? true}
         cursorTrailEnabled={settings.value.cursorTrailEnabled ?? true}
         {pane}
+        initialLine={pane === 'left' ? leftInitialLine.value : rightInitialLine.value}
         onContentChange={(content, leafId) => actions.updateLeafContent(content, leafId, pane)}
         onPush={actions.handlePushToGitHub}
         onClose={() => actions.closeLeaf(pane)}

--- a/src/components/views/EditorView.svelte
+++ b/src/components/views/EditorView.svelte
@@ -10,6 +10,7 @@
     linedMode?: boolean
     cursorTrailEnabled?: boolean
     pane: Pane
+    initialLine?: number
     onContentChange: (content: string, leafId: string) => void
     onPush: () => void
     onClose?: (() => void) | null
@@ -26,6 +27,7 @@
     linedMode = true,
     cursorTrailEnabled = true,
     pane,
+    initialLine = 0,
     onContentChange,
     onPush,
     onClose = null,
@@ -101,6 +103,7 @@
     {cursorTrailEnabled}
     leafId={leaf.id}
     {pane}
+    {initialLine}
     onChange={handleContentChange}
     {onPush}
     {onClose}

--- a/src/lib/pane-navigation.svelte.ts
+++ b/src/lib/pane-navigation.svelte.ts
@@ -33,6 +33,8 @@ import {
   rightLeaf,
   leftView,
   rightView,
+  leftInitialLine,
+  rightInitialLine,
   focusedPane,
   leftWorld,
   rightWorld,
@@ -288,8 +290,15 @@ export async function handleSearchResultClick(result: SearchMatch, pane: Pane = 
     } else {
       const leaf = targetLeaves.find((l) => l.id === result.leafId)
       if (leaf) {
+        // initialLine をセットしてから selectLeaf する。
+        // EditorView が {#key} で再マウントされる際に initialLine を読み取り、
+        // CodeMirror 初期化完了直後に自分でスクロールする（ポーリング不要）。
+        if (pane === 'left') {
+          leftInitialLine.value = result.line
+        } else {
+          rightInitialLine.value = result.line
+        }
         selectLeaf(leaf, pane)
-        await scrollLeafLineWhenReady(pane, leaf.id, result.line)
       }
     }
   }

--- a/src/lib/pane-navigation.svelte.ts
+++ b/src/lib/pane-navigation.svelte.ts
@@ -290,15 +290,22 @@ export async function handleSearchResultClick(result: SearchMatch, pane: Pane = 
     } else {
       const leaf = targetLeaves.find((l) => l.id === result.leafId)
       if (leaf) {
-        // initialLine をセットしてから selectLeaf する。
-        // EditorView が {#key} で再マウントされる際に initialLine を読み取り、
-        // CodeMirror 初期化完了直後に自分でスクロールする（ポーリング不要）。
-        if (pane === 'left') {
-          leftInitialLine.value = result.line
+        const currentLeafId = pane === 'left' ? leftLeaf.value?.id : rightLeaf.value?.id
+        if (currentLeafId === leaf.id) {
+          // 同一リーフが既に開いている場合: {#key} は変わらず再マウントされないため、
+          // 既存エディタに直接スクロール命令を送る（旧方式）。
+          await scrollLeafLineWhenReady(pane, leaf.id, result.line)
         } else {
-          rightInitialLine.value = result.line
+          // 別リーフに切り替わる場合: {#key} が変わり EditorView が再マウントされるため、
+          // initialLine をセットしておけば onMount 完了直後に自動スクロールする。
+          // ポーリング不要でネットワーク速度・デバイス性能に依存しない。
+          if (pane === 'left') {
+            leftInitialLine.value = result.line
+          } else {
+            rightInitialLine.value = result.line
+          }
+          selectLeaf(leaf, pane)
         }
-        selectLeaf(leaf, pane)
       }
     }
   }

--- a/src/lib/stores/stores.svelte.ts
+++ b/src/lib/stores/stores.svelte.ts
@@ -734,6 +734,27 @@ export const rightView = {
   },
 }
 
+// 検索結果クリック時に直接ジャンプする行番号（0 = ジャンプなし）
+let _leftInitialLine = $state<number>(0)
+export const leftInitialLine = {
+  get value() {
+    return _leftInitialLine
+  },
+  set value(v: number) {
+    _leftInitialLine = v
+  },
+}
+
+let _rightInitialLine = $state<number>(0)
+export const rightInitialLine = {
+  get value() {
+    return _rightInitialLine
+  },
+  set value(v: number) {
+    _rightInitialLine = v
+  },
+}
+
 // 同期状態ストア
 let _isPulling = $state<boolean>(false)
 export const isPulling = {


### PR DESCRIPTION
## 関連 Issue
closes #197

## 変更内容

### 問題
検索結果をクリックすると1回目はリーフ先頭行に飛び、2回目クリックでキーワード行に飛んでいた。

### 根本原因
`handleSearchResultClick` が `selectLeaf`（→ `{#key}` で EditorView 再マウント）と同時に `scrollLeafLineWhenReady` を呼んでいたが、`loadCodeMirror()`（dynamic import）の完了前にポーリングが終わってしまい `scrollToLine` が呼ばれなかった。

### 修正方針（方針A: prop 経由の抜本対策）
`initialLine` prop を `MarkdownEditor` / `EditorView` に追加し、`loadCodeMirror()` + `initializeEditor()` 完了直後に自分でスクロールさせる。ポーリングに依存しないため、ネットワーク速度・デバイス性能に左右されない。

### 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `src/lib/stores/stores.svelte.ts` | `leftInitialLine` / `rightInitialLine` リアクティブ変数を追加 |
| `src/lib/pane-navigation.svelte.ts` | `handleSearchResultClick` で `initialLine` をセット、`scrollLeafLineWhenReady` の呼び出しを削除 |
| `src/components/layout/PaneView.svelte` | `initialLine` を `EditorView` に渡す |
| `src/components/views/EditorView.svelte` | `initialLine` prop 追加、`MarkdownEditor` に渡す |
| `src/components/editor/MarkdownEditor.svelte` | `initialLine` prop 追加、`onMount` 末尾で `scrollToLine` 呼び出し |