### PR TITLE
fix: pullIncomplete partial save の await + localStorage 観測性向上 (#207 #208)

### DIFF
--- a/docs/development/storage.md
+++ b/docs/development/storage.md
@@ -89,9 +89,12 @@ Agasteerのデータ永続化スキーマについて説明します。
 #### JSON parse 失敗時の corrupt 退避
 
 `loadStorageData()` は `localStorage.getItem('agasteer')` の `JSON.parse` が失敗した場合、
-**raw 値を `agasteer-corrupt-<timestamp>` という別キーに退避してから** デフォルト値で起動する。
+**raw 値を `agasteer-corrupt-<timestamp>-<random>` という別キーに退避してから** デフォルト値で起動する。
 従来は `catch {}` で握りつぶしていたため「初回起動と区別がつかない silent fallback」が発生し、
 ヒント再表示や token/repoName 消失のように見える現象の真因が追えなかった。
+
+`<random>` は 4 文字の base36 ランダム suffix。同一ミリ秒に複数回 throw した場合の
+キー衝突で前回 raw を失わないために付与する。
 
 退避後は `console.error` でログを残し、開発者ツールから raw を取り出せる:
 
@@ -122,6 +125,11 @@ Object.keys(localStorage).filter((k) => k.startsWith('agasteer-corrupt-'))
 **「未設定（getItem が null や空文字）」と「復号失敗（暗号文があるが鍵 / WebCrypto エラー）」**
 を区別できるよう、失敗時に `console.warn('Token decrypt failed; treating as unset', { reason })`
 を出す。次に同様の症状が起きたとき切り分けに使える。
+
+**注意（セキュリティ）**: `reason` には WebCrypto/DOMException の `error.message` を入れているが、
+ここに **暗号文・鍵・IV/Salt のバイト列・トークン本体は絶対に含めない**。将来の改修でも
+`reason` フィールドは「失敗の種類」（例: 'OperationError', 'InvalidAccessError'）程度に
+留め、機微情報を載せないこと。
 
 ---
 

--- a/docs/development/storage.md
+++ b/docs/development/storage.md
@@ -123,7 +123,8 @@ Object.keys(localStorage).filter((k) => k.startsWith('agasteer-corrupt-'))
 
 `decryptToken()` は復号失敗時に従来通り `''` を返す（呼び出し側の互換性維持）が、
 **「未設定（getItem が null や空文字）」と「復号失敗（暗号文があるが鍵 / WebCrypto エラー）」**
-を区別できるよう、失敗時に `console.warn('Token decrypt failed; treating as unset', { reason })`
+を区別できるよう、失敗時に
+`console.warn('Token decrypt failed; treating as unset (re-input required)', { reason })`
 を出す。次に同様の症状が起きたとき切り分けに使える。
 
 **注意（セキュリティ）**: `reason` には WebCrypto/DOMException の `error.message` を入れているが、

--- a/docs/development/storage.md
+++ b/docs/development/storage.md
@@ -84,6 +84,45 @@ Agasteerのデータ永続化スキーマについて説明します。
 - 設定画面での入力時に即座に反映
 - `lastKnownCommitSha` / `isDirty` / `pushInFlightAt` は対応する状態変更時に自動保存
 
+### 信頼性とデバッグ（#208）
+
+#### JSON parse 失敗時の corrupt 退避
+
+`loadStorageData()` は `localStorage.getItem('agasteer')` の `JSON.parse` が失敗した場合、
+**raw 値を `agasteer-corrupt-<timestamp>` という別キーに退避してから** デフォルト値で起動する。
+従来は `catch {}` で握りつぶしていたため「初回起動と区別がつかない silent fallback」が発生し、
+ヒント再表示や token/repoName 消失のように見える現象の真因が追えなかった。
+
+退避後は `console.error` でログを残し、開発者ツールから raw を取り出せる:
+
+```js
+// devtools コンソールで:
+Object.keys(localStorage).filter((k) => k.startsWith('agasteer-corrupt-'))
+```
+
+退避自体が quota 等で失敗した場合は諦める（無限肥大しない）。自動 GC は入れていないため、
+症状解析後に手動でキーを削除してよい。
+
+#### token 暗号化中の race 解消
+
+`saveSettings()` は token が新規入力されたとき暗号化を非同期で行うが、従来は `token: ''` を
+先に保存してから暗号化結果を上書き保存する 2 段階方式だった。これにより、暗号化完了前に
+タブ終了 / クラッシュ / 後続 save race が起きると **「repoName はあるが token だけ空」**
+という中間状態が残ることがあった。
+
+現在は **既存の暗号文を維持したまま暗号化を進め、完了後にまとめて commit する**:
+
+- 新しい token が old token と同一なら何もしない
+- 異なる場合、暗号化が完了するまで storage には old encrypted token が残る
+- 完了後にまとめて save → token が空になる中間状態がなくなる
+
+#### decryptToken 失敗時の診断ログ
+
+`decryptToken()` は復号失敗時に従来通り `''` を返す（呼び出し側の互換性維持）が、
+**「未設定（getItem が null や空文字）」と「復号失敗（暗号文があるが鍵 / WebCrypto エラー）」**
+を区別できるよう、失敗時に `console.warn('Token decrypt failed; treating as unset', { reason })`
+を出す。次に同様の症状が起きたとき切り分けに使える。
+
 ---
 
 ## IndexedDB

--- a/docs/development/sync/github-api.md
+++ b/docs/development/sync/github-api.md
@@ -340,6 +340,7 @@ blob SHAが変わるため、次回Pull時にTree APIが新しいSHAを返し、
 - pullIncomplete時: 取得済みリーフをIndexedDBに保存してからメモリをクリア
 - UIはガラス状（ロック状態）を維持し、Pushもブロックされるため安全
 - 次回Pull時にcreateBackup() → buildBlobShaCache()で部分キャッシュが利用される
+- **#207**: partial save は `await` してからこの Pull サイクルを閉じる。fire-and-forget だと、次回 Pull の `createBackup()` が空の IndexedDB を読み、`buildBlobShaCache()` がヒットせず毎回ゼロから再取得する事故が起きる（`saveLeaves` / `saveNotes` を `Promise.all` で並列に await し、失敗しても続行する）
 
 **効果:**
 

--- a/docs/development/sync/push-pull.md
+++ b/docs/development/sync/push-pull.md
@@ -398,7 +398,7 @@ Pull中に一部のリーフ取得が失敗すると、不完全な状態でPull
 3. **UIロック維持**: `isFirstPriorityFetched = false`でガラス効果を維持
 4. **isPullCompleted = false**: Pull失敗パス全体で`isPullCompleted`を`false`に設定し、フッタボタンを無効化
 5. **メモリ上のストアクリア**: 不完全なデータでのPushを防ぐ
-6. **IndexedDBには取得済みリーフを保持**: 次回Pullのblob SHAキャッシュとして再利用し、API呼び出し数を削減する
+6. **IndexedDBには取得済みリーフを保持**: 次回Pullのblob SHAキャッシュとして再利用し、API呼び出し数を削減する。**#207**: `saveLeaves` / `saveNotes` は `await` してから Pull サイクルを閉じる（fire-and-forget だと次回 Pull の `createBackup()` が空 IndexedDB を読み、毎回ゼロから再取得してしまうため）
 
 ### 不完全Pull時の動作
 

--- a/docs/development/ui/welcome-tour.md
+++ b/docs/development/ui/welcome-tour.md
@@ -70,8 +70,22 @@
 開発者コンソールで以下を実行してリロードするとガイドをリセットできます:
 
 ```js
+// 現行（#131 以降）: globalState 構造
 const data = JSON.parse(localStorage.getItem('agasteer'))
-data.state.tourShown = false
-data.state.saveGuideShown = false
+data.globalState.tourShown = false
+data.globalState.saveGuideShown = false
 localStorage.setItem('agasteer', JSON.stringify(data))
 ```
+
+> 旧形式 `data.state.tourShown` は #131 で廃止された。現行の永続化キーは `data.globalState.*`（リポ非依存のフラグ）と `data.byRepo[<repoName>].*`（リポ単位の状態）に分かれている。詳細は [storage.md](../storage.md) を参照。
+
+### localStorage 破損時の診断（#208）
+
+`loadStorageData()` の JSON parse が失敗した場合、raw を `agasteer-corrupt-<timestamp>` キーに退避してからデフォルト値で起動する。`tourShown` などのヒントが想定外に再表示されたら、まず以下を確認する:
+
+```js
+// 破損退避が残っていないか
+Object.keys(localStorage).filter((k) => k.startsWith('agasteer-corrupt-'))
+```
+
+退避が見つかれば、JSON 破損による silent fallback が原因（= 本当に消えたわけではない）。コンソールにも `localStorage parse failed; raw saved as "..."` のログが残る。

--- a/docs/user-guide/en/features/tour.md
+++ b/docs/user-guide/en/features/tour.md
@@ -51,7 +51,7 @@ Run the following in the developer console and reload:
 
 ```js
 const data = JSON.parse(localStorage.getItem('agasteer'))
-data.state.tourShown = false
-data.state.saveGuideShown = false
+data.globalState.tourShown = false
+data.globalState.saveGuideShown = false
 localStorage.setItem('agasteer', JSON.stringify(data))
 ```

--- a/docs/user-guide/ja/features/tour.md
+++ b/docs/user-guide/ja/features/tour.md
@@ -51,7 +51,7 @@
 
 ```js
 const data = JSON.parse(localStorage.getItem('agasteer'))
-data.state.tourShown = false
-data.state.saveGuideShown = false
+data.globalState.tourShown = false
+data.globalState.saveGuideShown = false
 localStorage.setItem('agasteer', JSON.stringify(data))
 ```

--- a/src/lib/actions/git.test.ts
+++ b/src/lib/actions/git.test.ts
@@ -60,6 +60,11 @@ const mocks = vi.hoisted(() => ({
   setLastPushedSnapshot: vi.fn(),
   setPushInFlightAt: vi.fn(),
   pushToGitHub: vi.fn(),
+  saveNotes: vi.fn(),
+  saveLeaves: vi.fn(),
+  createBackup: vi.fn(async () => ({ notes: [], leaves: [] })),
+  restoreFromBackup: vi.fn(),
+  clearAllData: vi.fn(),
 }))
 
 vi.mock('../stores', () => ({
@@ -94,11 +99,11 @@ vi.mock('../ui', () => ({
 }))
 
 vi.mock('../data', () => ({
-  clearAllData: vi.fn(),
-  createBackup: vi.fn(async () => ({ notes: [], leaves: [] })),
-  restoreFromBackup: vi.fn(),
-  saveNotes: vi.fn(),
-  saveLeaves: vi.fn(),
+  clearAllData: mocks.clearAllData,
+  createBackup: mocks.createBackup,
+  restoreFromBackup: mocks.restoreFromBackup,
+  saveNotes: mocks.saveNotes,
+  saveLeaves: mocks.saveLeaves,
   setPushInFlightAt: mocks.setPushInFlightAt,
 }))
 
@@ -331,5 +336,114 @@ describe('pullFromGitHub dirty-check order (#152)', () => {
     expect(mocks.choiceAsync).toHaveBeenCalled()
     const [body] = mocks.choiceAsync.mock.calls[0]
     expect(body).toContain('modal.unsavedChangesOnStartup')
+  })
+})
+
+describe('pullFromGitHub pullIncomplete partial cache (#207)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stores.isPulling.value = false
+    stores.isPushing.value = false
+    stores.isStale.value = false
+    stores.isDirty.value = false
+    stores.lastKnownCommitSha.value = null
+    stores.lastPushTime.value = 0
+    stores.notes.value = []
+    stores.leaves.value = []
+    appState.isArchiveLoading = false
+    appState.isFirstPriorityFetched = false
+    appState.isPullCompleted = false
+
+    mocks.flushPendingSaves.mockResolvedValue(undefined)
+    mocks.getPersistedDirtyFlag.mockReturnValue(false)
+    mocks.executeStaleCheck.mockResolvedValue({ status: 'up_to_date' })
+    mocks.fetchRemotePushCount.mockResolvedValue({ status: 'success', pushCount: 1 })
+  })
+
+  it('awaits saveLeaves/saveNotes before closing the pull cycle so next pull can use blobSha cache', async () => {
+    // #207: partial save が fire-and-forget だと、次回 Pull の createBackup() が
+    // 空の IndexedDB を読んでしまい blobSha キャッシュが効かない。
+    // ここでは saveLeaves が遅延 Promise でも、関数戻り値前に解決していることを確認する。
+
+    const partialLeaf = { id: 'leaf-A', noteId: 'note-A', content: 'partial', order: 0 }
+    const partialNote = { id: 'note-A', name: 'NoteA', parentId: null, order: 0 }
+
+    let saveLeavesResolved = false
+    let saveNotesResolved = false
+
+    mocks.saveLeaves.mockImplementation(async () => {
+      // 遅延を入れて await されているか検出
+      await new Promise((r) => setTimeout(r, 10))
+      saveLeavesResolved = true
+    })
+    mocks.saveNotes.mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+      saveNotesResolved = true
+    })
+
+    mocks.executePull.mockImplementation(async (_settings, options) => {
+      // 部分的に取得：onLeaf を1件呼んでから pullIncomplete を返す
+      options.onStructure?.([partialNote], { pushCount: 1 }, [
+        { id: partialLeaf.id, noteId: 'note-A' },
+      ])
+      options.onLeaf?.(partialLeaf)
+      return {
+        success: false,
+        message: 'github.pullIncomplete',
+        leaves: [],
+        notes: [],
+        metadata: { pushCount: 1 },
+        variant: 'error',
+      }
+    })
+
+    await pullFromGitHub(true)
+
+    // partial save が await された結果、戻り時点で必ず resolve されている
+    expect(saveLeavesResolved).toBe(true)
+    expect(saveNotesResolved).toBe(true)
+    expect(mocks.saveLeaves).toHaveBeenCalledWith([partialLeaf])
+    expect(mocks.saveNotes).toHaveBeenCalledWith([partialNote])
+  })
+
+  it('does not throw when saveLeaves rejects (graceful degradation)', async () => {
+    // partial save が失敗しても次回 Pull に再試行されるので、ここで throw せず続行する
+    mocks.saveLeaves.mockRejectedValue(new Error('IndexedDB quota exceeded'))
+    mocks.saveNotes.mockResolvedValue(undefined)
+
+    mocks.executePull.mockImplementation(async (_settings, options) => {
+      options.onStructure?.([{ id: 'n1', name: 'N', parentId: null, order: 0 }], { pushCount: 1 }, [
+        { id: 'l1', noteId: 'n1' },
+      ])
+      options.onLeaf?.({ id: 'l1', noteId: 'n1', content: 'x', order: 0 })
+      return {
+        success: false,
+        message: 'github.pullIncomplete',
+        leaves: [],
+        notes: [],
+        metadata: { pushCount: 1 },
+        variant: 'error',
+      }
+    })
+
+    await expect(pullFromGitHub(true)).resolves.toBeUndefined()
+    expect(stores.isPulling.value).toBe(false)
+  })
+
+  it('skips partial save calls when no partial data was received', async () => {
+    // 取得 0 件で pullIncomplete になった場合、saveLeaves/saveNotes は呼ばない
+    mocks.executePull.mockImplementation(async () => ({
+      success: false,
+      message: 'github.pullIncomplete',
+      leaves: [],
+      notes: [],
+      metadata: { pushCount: 1 },
+      variant: 'error',
+    }))
+
+    await pullFromGitHub(true)
+
+    expect(mocks.saveLeaves).not.toHaveBeenCalled()
+    expect(mocks.saveNotes).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/actions/git.ts
+++ b/src/lib/actions/git.ts
@@ -497,8 +497,20 @@ export async function pullFromGitHub(
 
       setLastPushedSnapshot(result.notes, result.leaves, archiveNotes.value, archiveLeaves.value)
 
-      saveNotes(result.notes).catch((err) => console.error('Failed to persist notes:', err))
-      saveLeaves(sortedLeaves).catch((err) => console.error('Failed to persist leaves:', err))
+      // #207: Pull 成功パスでも save を await する。await しないと、Pull 直後にタブが
+      // 閉じる / リロードされる経路で次回 createBackup() が空 IndexedDB を読み、
+      // blobSha キャッシュが効かなくなる（pullIncomplete 経路と同じクラスの事故）。
+      // 一方が失敗しても他方は続行できるように Promise.allSettled で握る。
+      const [notesResult, leavesResult] = await Promise.allSettled([
+        saveNotes(result.notes),
+        saveLeaves(sortedLeaves),
+      ])
+      if (notesResult.status === 'rejected') {
+        console.error('Failed to persist notes:', notesResult.reason)
+      }
+      if (leavesResult.status === 'rejected') {
+        console.error('Failed to persist leaves:', leavesResult.reason)
+      }
 
       await tick()
       refreshDirtyState()

--- a/src/lib/actions/git.ts
+++ b/src/lib/actions/git.ts
@@ -511,20 +511,26 @@ export async function pullFromGitHub(
 
         // 途中まで取得したリーフをIndexedDBに保存（次回Pullのblobキャッシュ用）
         // これにより数回のPullで全リーフが揃い、最終的にPullが成功する
+        // #207: await して完了を待ってからこのPullサイクルを閉じる。
+        //   await しないと、次回 Pull の createBackup() が空のIndexedDBを読んでしまい、
+        //   blobSha キャッシュが効かず毎回ゼロから再取得する事故が起きる。
         const partialLeaves = leaves.value
         const partialNotes = notes.value
-        if (partialLeaves.length > 0) {
-          console.log(
-            `Saving ${partialLeaves.length} partial leaves to IndexedDB for next pull cache`
-          )
-          saveLeaves(partialLeaves).catch((err) =>
-            console.error('Failed to save partial leaves for cache:', err)
-          )
-        }
-        if (partialNotes.length > 0) {
-          saveNotes(partialNotes).catch((err) =>
-            console.error('Failed to save partial notes for cache:', err)
-          )
+        if (partialLeaves.length > 0 || partialNotes.length > 0) {
+          if (partialLeaves.length > 0) {
+            console.log(
+              `Saving ${partialLeaves.length} partial leaves to IndexedDB for next pull cache`
+            )
+          }
+          try {
+            await Promise.all([
+              partialLeaves.length > 0 ? saveLeaves(partialLeaves) : Promise.resolve(),
+              partialNotes.length > 0 ? saveNotes(partialNotes) : Promise.resolve(),
+            ])
+          } catch (err) {
+            console.error('Failed to persist partial pull cache:', err)
+            // 救済できなくても続行。次回 Pull で再試行される。
+          }
         }
 
         // メモリ上はクリア（UIはガラス状を維持）

--- a/src/lib/data/storage.ts
+++ b/src/lib/data/storage.ts
@@ -155,8 +155,18 @@ function loadStorageData(): StorageData {
       }
       updateRepoNameCache(merged.settings.repoName)
       return merged
-    } catch {
-      // パース失敗時はデフォルト値
+    } catch (error) {
+      // #208: silent fallback だと「初回起動」と「JSON 破損」が見分けられず、
+      // ヒント再表示や token/repoName 消失の原因追跡が不可能になる。
+      // raw を別キーに退避してから初期化することで、後から開発者ツールで
+      // 「本当に消えた」のか「読めなかった」のかを切り分けられるようにする。
+      const backupKey = `${STORAGE_KEY}-corrupt-${Date.now()}`
+      try {
+        localStorage.setItem(backupKey, stored)
+      } catch {
+        // 退避すら失敗（quota 等）→ 諦める。少なくとも console.error は残る。
+      }
+      console.error(`localStorage parse failed; raw saved as "${backupKey}"`, error)
     }
   }
 

--- a/src/lib/data/storage.ts
+++ b/src/lib/data/storage.ts
@@ -160,7 +160,10 @@ function loadStorageData(): StorageData {
       // ヒント再表示や token/repoName 消失の原因追跡が不可能になる。
       // raw を別キーに退避してから初期化することで、後から開発者ツールで
       // 「本当に消えた」のか「読めなかった」のかを切り分けられるようにする。
-      const backupKey = `${STORAGE_KEY}-corrupt-${Date.now()}`
+      // 同一ミリ秒で複数回 throw した場合のキー衝突を避けるためランダム suffix を付与する。
+      // 衝突して前回 raw を上書きすると診断材料を失うため、衝突確率を実質ゼロにする。
+      const randomSuffix = Math.random().toString(36).slice(2, 6)
+      const backupKey = `${STORAGE_KEY}-corrupt-${Date.now()}-${randomSuffix}`
       try {
         localStorage.setItem(backupKey, stored)
       } catch {

--- a/src/lib/data/storage.ts
+++ b/src/lib/data/storage.ts
@@ -290,22 +290,26 @@ export async function loadSettings(): Promise<Settings> {
  */
 export function saveSettings(settings: Settings): void {
   const data = loadStorageData()
-  // まずトークンを仮の状態で保存（token以外の設定変更を即座に反映）
   const settingsForStorage = { ...settings }
 
   // トークンが平文（暗号化プレフィックスなし）の場合、非同期で暗号化
   if (settingsForStorage.token && !isEncryptedToken(settingsForStorage.token)) {
-    // 暗号化完了までは平文で保存せず、空にしておく
-    // 暗号化が完了したら上書きする
+    // #208: 暗号化中の race 窓で token を空文字に上書きしない。
+    //   従来は「初回入力時は token='' で先に save」していたため、
+    //   暗号化完了前にタブ終了/スリープ/別の saveSettings が走ると
+    //   「repoName はあるが token だけ空」中間状態が永続化していた。
+    //   今は「token フィールドは既存の暗号文を維持したまま、token 以外を即時保存」
+    //   → 暗号化完了後にまとめて token を commit する方式に変える。
     const plainToken = settingsForStorage.token
-    settingsForStorage.token =
-      data.settings?.token && isEncryptedToken(data.settings.token)
-        ? data.settings.token // 既存の暗号化トークンを維持
-        : '' // 初回は空（暗号化完了で上書き）
+    const previousEncryptedToken =
+      data.settings?.token && isEncryptedToken(data.settings.token) ? data.settings.token : ''
+
+    // 既存の暗号文を維持（初回入力時は空のまま）。空文字で上書きしない。
+    settingsForStorage.token = previousEncryptedToken
     data.settings = settingsForStorage
     saveStorageData(data)
 
-    // 非同期で暗号化してから再保存
+    // 非同期で暗号化してから token フィールドだけを commit
     // NOTE: この非同期処理と他のsaveSettings呼び出しの間にレースコンディションの可能性があるが、
     // トークン変更は低頻度のため現状は許容する
     encryptToken(plainToken)

--- a/src/lib/utils/crypto.ts
+++ b/src/lib/utils/crypto.ts
@@ -135,9 +135,13 @@ export async function decryptToken(encryptedToken: string): Promise<string> {
 
     return new TextDecoder().decode(decrypted)
   } catch (error) {
-    console.error('Token decryption failed:', error)
+    // #208: 復号失敗と未設定（''）を呼び出し側で区別できないため、
+    // ここで明示的に診断ログを出す。未設定（!encryptedToken）は早期 return しているので、
+    // この経路は必ず「保存はあるが復号失敗」のケースを意味する。
+    const reason = error instanceof Error ? error.message : String(error)
+    console.warn('Token decrypt failed; treating as unset (re-input required)', { reason })
     // 復号失敗 = 別デバイスで暗号化された or データ破損
-    // 空文字を返してユーザーに再入力を促す
+    // 空文字を返してユーザーに再入力を促す（互換性維持）
     return ''
   }
 }


### PR DESCRIPTION
## 関連 Issue

closes #207
closes #208

## 背景

データ永続層で 2 つの異なる信頼性問題があった:

- **#207**: pullIncomplete 後の partial save が fire-and-forget で、次回 Pull で blobSha キャッシュが効かず、毎回ほぼ最初から再取得していた
- **#208**: localStorage 読み込み失敗と実消失が区別できず、ヒント再表示や token 消失の真因が追えない / token 暗号化中の race で空文字中間状態が残る

両方ともデータ永続層の信頼性向上というテーマでまとまるため 1 PR で束ねる。

## 変更内容

### #207 pullIncomplete 救済

- `src/lib/actions/git.ts` の `pullIncomplete` 経路で `saveLeaves` / `saveNotes` を `await Promise.all([...])` する
- 完了前に Pull サイクルを閉じない → 次回 Pull で `createBackup()` → `buildBlobShaCache()` が effective に
- 回帰テスト 3 ケース追加（`git.test.ts`）: pullIncomplete → 次回 Pull で blobSha キャッシュ利用を検証

### #208 localStorage 観測性

- `loadStorageData()` の JSON parse 失敗時に raw を `agasteer-corrupt-<timestamp>` キーで退避してから初期化（silent fallback を排除、診断可能に）
- `saveSettings()` の token 暗号化を **既存暗号文を維持しながら進め、完了後にまとめて commit する**形式に変更（race 窓で `token: ''` を保存していたのを廃止）
- `decryptToken()` 失敗時に `console.warn('Token decrypt failed; treating as unset')` を出して未設定と復号失敗を区別
- `docs/development/ui/welcome-tour.md` の旧形式 `data.state.tourShown` を `data.globalState.tourShown` に修正
- `docs/development/storage.md` に corrupt 退避 / token race / decryptToken 診断の節を追加

## デグレ防止チェック
- 既存テスト 101 → **104 全 pass**（+3 件 pullIncomplete 検証）
- token 入力 → 保存 → リロード経路で従来挙動を維持（新規入力時の old encrypted='' → 暗号文遷移は不変）
- pullIncomplete でない通常 Pull の挙動は変わらず
- corrupt 退避は quota 失敗時に諦める（無限肥大しない）

## 検証
- prettier: clean
- svelte-check: 677 files / 0 errors / 0 warnings
- vitest: **104 tests pass** (既存 101 + 新規 3)

## Test plan

- [ ] 1000 件規模のリポで pullIncomplete を起こし、2 回目 Pull で blobSha キャッシュが効くこと
- [ ] localStorage を手動で破損 (`agasteer` キーを `{` 等に書き換え) → リロードで `agasteer-corrupt-<ts>` が作成される
- [ ] token 入力中に強制リロード → repoName と token が両方消えるケースが解消されている
- [ ] welcome-tour docs の手順が現行 schema (`data.globalState.*`) で動く