### PR TITLE
feat: ノートカード左辺にバインダー綴じ風模様を追加 (#209)

### DIFF
--- a/src/components/cards/NoteCard.svelte
+++ b/src/components/cards/NoteCard.svelte
@@ -84,17 +84,57 @@
 <style>
   .note-card {
     position: relative;
-    padding: 1rem;
+    /* #209: 左辺バインダー綴じ模様の帯（8px）を確保するため、左 padding を増やす。
+       他方向は 1rem 維持 */
+    padding: 1rem 1rem 1rem 1.4rem;
     border: 1px solid var(--border);
     border-radius: 8px;
     background: var(--surface-1);
     cursor: pointer;
     transition: all 0.2s;
+    /* overflow: visible は維持（BadgeButton 等のドロップダウンが外に出る場合に備え）。
+       バインダー模様は absolute で left:4px / width:4px なのでカード内に収まる */
     overflow: visible;
     /* 高さ固定: タイトル1行 + 4行のアイテム（3行+...）を表示できる高さ */
     height: 150px;
     min-height: 150px;
     max-height: 150px;
+  }
+
+  /* #209: バインダー綴じ風模様
+     ノートカードの左辺内側に「2 本の細線 + 余白」を縦に反復させ、
+     リングノートの綴じを連想させる。リーフカードには付けないことで識別性を高める。
+     - カード矩形の外には絶対にはみ出さない（width 4px + 内側 left:4px の absolute 配置）
+     - 色はテーマ accent の半透明で控えめに
+     - 細線 1px x 2 本（間 1px）で 1 セット、セット間隔 12px */
+  .note-card::before {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 10px;
+    bottom: 10px;
+    width: 4px;
+    background-image: repeating-linear-gradient(
+      to bottom,
+      var(--accent) 0 1px,
+      transparent 1px 3px,
+      var(--accent) 3px 4px,
+      transparent 4px 14px
+    );
+    opacity: 0.35;
+    pointer-events: none;
+    border-radius: 1px;
+  }
+
+  /* スマホでは帯幅を細めにして本文幅を圧迫しないようにする */
+  @media (max-width: 480px) {
+    .note-card {
+      padding-left: 1.2rem;
+    }
+    .note-card::before {
+      left: 3px;
+      width: 3px;
+    }
   }
 
   .note-title {

--- a/src/components/cards/NoteCard.svelte
+++ b/src/components/cards/NoteCard.svelte
@@ -84,8 +84,8 @@
 <style>
   .note-card {
     position: relative;
-    /* #209: 左辺バインダー綴じ模様の帯（8px）を確保するため、左 padding を増やす。
-       他方向は 1rem 維持 */
+    /* #209: 左辺バインダー綴じ模様の帯（4px 幅、左端から 8px の領域）を確保するため、
+       左 padding を増やす。他方向は 1rem 維持 */
     padding: 1rem 1rem 1rem 1.4rem;
     border: 1px solid var(--border);
     border-radius: 8px;
@@ -106,7 +106,7 @@
      リングノートの綴じを連想させる。リーフカードには付けないことで識別性を高める。
      - カード矩形の外には絶対にはみ出さない（width 4px + 内側 left:4px の absolute 配置）
      - 色はテーマ accent の半透明で控えめに
-     - 細線 1px x 2 本（間 1px）で 1 セット、セット間隔 12px */
+     - 細線 1px x 2 本（間 2px）で 1 セット、セット周期 14px */
   .note-card::before {
     content: '';
     position: absolute;


### PR DESCRIPTION
## 関連 Issue

closes #209

## 変更内容

ノートカードの左辺内側に「2 本の細線 + 余白」を縦に反復させたバインダー綴じ風模様を追加。リーフと一目で見分けられるようになる。

### 実装
- `src/components/cards/NoteCard.svelte` の `::before` 擬似要素で `repeating-linear-gradient` を使用
- 1px 線 × 2 本（間 2px）+ 余白 10px で 1 セット、14px 周期で縦反復
- `var(--accent)` を `opacity: 0.35` で薄く適用 → テーマに馴染む
- 帯幅 4px、`left: 4px` の絶対配置で **カード矩形の外には絶対にはみ出さない**
- 左 padding を `1rem → 1.4rem` に増やして本文と模様の間に余白を確保
- スマホ (`max-width: 480px`) では帯幅 3px / left 3px に縮小

### リーフへの非適用
NoteView.svelte の leaf-card (`class="note-card leaf-card"`) は **コンポーネントスコープの style しか効かない**ため、`NoteCard.svelte` 内の `::before` は **NoteCard 経由で描画されるノートカードのみ** に適用される。リーフカードには無し → 識別性が上がる。

## 検証
- prettier: clean
- svelte-check: 677 files / 0 errors / 0 warnings
- vitest: 107/107 tests pass

## Test plan
- [ ] ノートカードに左辺の綴じ模様が見える
- [ ] リーフカードには付かない
- [ ] カード hover / selected / drag-over で模様が崩れない
- [ ] スマホ表示で本文幅が極端に狭くならない
- [ ] テーマ切替で模様の色も追従する