### PR TITLE
fix: バインダー綴じ模様を左端密着 + 縦長拡張、スマホ分岐削除 (#209 followup)

### DIFF
--- a/src/components/cards/NoteCard.svelte
+++ b/src/components/cards/NoteCard.svelte
@@ -84,8 +84,8 @@
 <style>
   .note-card {
     position: relative;
-    /* #209: 左辺バインダー綴じ模様の帯（4px 幅、左端から 8px の領域）を確保するため、
-       左 padding を増やす。他方向は 1rem 維持 */
+    /* #209: 左辺バインダー綴じ模様の帯（4px 幅、左端 0 に密着）と本文の間に
+       余白を取るため、左 padding を増やす。他方向は 1rem 維持 */
     padding: 1rem 1rem 1rem 1.4rem;
     border: 1px solid var(--border);
     border-radius: 8px;
@@ -93,7 +93,7 @@
     cursor: pointer;
     transition: all 0.2s;
     /* overflow: visible は維持（BadgeButton 等のドロップダウンが外に出る場合に備え）。
-       バインダー模様は absolute で left:4px / width:4px なのでカード内に収まる */
+       バインダー模様は absolute で left:0 / width:4px なのでカード内に収まる */
     overflow: visible;
     /* 高さ固定: タイトル1行 + 4行のアイテム（3行+...）を表示できる高さ */
     height: 150px;

--- a/src/components/cards/NoteCard.svelte
+++ b/src/components/cards/NoteCard.svelte
@@ -102,17 +102,18 @@
   }
 
   /* #209: バインダー綴じ風模様
-     ノートカードの左辺内側に「2 本の細線 + 余白」を縦に反復させ、
+     ノートカードの**左辺に密着**させた帯（左端 0px）に「2 本の細線 + 余白」を縦に反復させ、
      リングノートの綴じを連想させる。リーフカードには付けないことで識別性を高める。
-     - カード矩形の外には絶対にはみ出さない（width 4px + 内側 left:4px の absolute 配置）
+     - 矩形の左端からそのまま生やす（border 上に重ねるのでカードの輪郭と一体化）
      - 色はテーマ accent の半透明で控えめに
+     - 縦範囲はほぼ全長（top:4 / bottom:4、border-radius:8px の角丸内に収まる）
      - 細線 1px x 2 本（間 2px）で 1 セット、セット周期 14px */
   .note-card::before {
     content: '';
     position: absolute;
-    left: 4px;
-    top: 10px;
-    bottom: 10px;
+    left: 0;
+    top: 4px;
+    bottom: 4px;
     width: 4px;
     background-image: repeating-linear-gradient(
       to bottom,
@@ -123,7 +124,6 @@
     );
     opacity: 0.35;
     pointer-events: none;
-    border-radius: 1px;
   }
 
   /* スマホでは帯幅を細めにして本文幅を圧迫しないようにする */
@@ -132,7 +132,6 @@
       padding-left: 1.2rem;
     }
     .note-card::before {
-      left: 3px;
       width: 3px;
     }
   }

--- a/src/components/cards/NoteCard.svelte
+++ b/src/components/cards/NoteCard.svelte
@@ -126,16 +126,6 @@
     pointer-events: none;
   }
 
-  /* スマホでは帯幅を細めにして本文幅を圧迫しないようにする */
-  @media (max-width: 480px) {
-    .note-card {
-      padding-left: 1.2rem;
-    }
-    .note-card::before {
-      width: 3px;
-    }
-  }
-
   .note-title {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## 関連 Issue

#209 の追加調整（kako-jun フィードバック）

## 変更内容

PR #215 でマージしたバインダー綴じ模様への調整:
- **`left: 4px` → `0`**: 矩形左端に密着させ、border と一体化させる（リングノート感を強める）
- **`top/bottom: 10px → 4px`**: 縦範囲を最大化（実質 1.5 倍に伸びる）
- **`border-radius: 1px` 削除**: 左端密着で不要に
- **スマホ専用分岐削除**: `@media (max-width: 480px)` の `width: 3px` / `padding-left: 1.2rem` を削除し、デスクトップと統一

## 検証
- prettier + svelte-check: clean
- vitest: 107/107 tests pass（CSS のみの変更）