### PR TITLE
fix: バインダー模様の上下余白を対称化 (#209 followup 3)

### DIFF
--- a/src/components/cards/NoteCard.svelte
+++ b/src/components/cards/NoteCard.svelte
@@ -124,6 +124,11 @@
       var(--accent) 3px 4px,
       transparent 4px 14px
     );
+    /* カード高さ 150px 固定 + top/bottom:13px → 縦範囲 124px。
+       周期 14px とは割り切れず、デフォルトでは上余白 0 / 下余白 8px の不均衡が出る。
+       gradient を 4px 下にオフセットして上下を対称（4px ずつ）にする。
+       線位置: 4..5 / 7..8 / 18..19 / 21..22 / ... / 116..117 / 119..120 → 下余白 4px。 */
+    background-position: 0 4px;
     opacity: 0.35;
     pointer-events: none;
   }


### PR DESCRIPTION
## 関連 Issue
#209 の追加調整 3 周目（kako-jun フィードバック）

## 変更内容
- `background-position: 0 4px;` を追加し、gradient 全体を 4px 下にオフセット
- カード高さ 150px 固定 + top/bottom 13px の縦範囲 124px は周期 14px と割り切れず、デフォルトでは上 0 / 下 8px の不均衡だった
- 修正後: 上余白 4px / 下余白 4px の対称配置

## 検証
prettier + svelte-check: clean