### PR TITLE
ci: lint + test ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
 permissions:
   contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -27,6 +27,8 @@ npm run check
 npm run lint
 ```
 
+push および pull request では GitHub Actions（`.github/workflows/ci.yml`）が `npm run lint`（format:check + svelte-check）と `npm test` を自動実行する。ローカルの husky pre-commit に加え、リモート側でも品質ゲートがかかる。
+
 ### ビルド
 
 ```bash

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -41,7 +41,7 @@ npm run preview
 
 ### デプロイ
 
-`main`ブランチへのプッシュで自動デプロイ（GitHub Actions）。
+`main`ブランチへのプッシュで Cloudflare Pages が自動ビルド・デプロイする（Cloudflare の Git 連携）。GitHub Actions（`.github/workflows/ci.yml`）は lint + test の品質ゲートのみで、デプロイは行わない。
 
 ```bash
 git add .


### PR DESCRIPTION
closes #227

## 概要
`.github/` が無く husky の pre-commit `npm run lint` のみで、約121テスト・svelte-check が push/PR で自動実行されていなかった。最小 GitHub Actions を1本追加して PR ゲート化する。

## 変更
- `.github/workflows/ci.yml` を追加
  - トリガー: `push`（main）/ `pull_request`
  - `permissions: contents: read`
  - Node 22 + `cache: npm`、`HUSKY: 0`
  - `npm ci` → `npm run lint`（format:check + svelte-check）→ `npm test`（vitest run）
- `docs/development/development.md` に CI の記述を追記（push/PR でリモート品質ゲートがかかる旨）

## ローカル検証
- `npm run lint`: 緑（prettier All matched files use Prettier code style / svelte-check 0 ERRORS 0 WARNINGS）
- `npm test`: 緑（15 files / 121 tests passed）