### PR TITLE
refactor: github.ts 純粋層を github/ 配下へ分離（#226 Phase 1）

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -170,7 +170,12 @@ agasteer/
 │   │   ├── breadcrumbs.ts               # パンくずリスト生成
 │   │   ├── drag-drop.ts                 # ドラッグ&ドロップヘルパー
 │   │   ├── font.ts                      # カスタムフォント管理
-│   │   ├── github.ts                    # GitHub API統合
+│   │   ├── github.ts                    # GitHub API統合（副作用層: push/pull/http）
+│   │   ├── github/                       # GitHub 純粋層（Phase 1で分離）
+│   │   │   ├── paths.ts                 # パス定数・パス構築（純粋）
+│   │   │   ├── encoding.ts              # Base64/UTF-8変換（純粋）
+│   │   │   ├── sha.ts                   # Git blob SHA計算（純粋）
+│   │   │   └── rate-limit.ts            # レート制限解析（純粋）
 │   │   ├── routing.ts                   # URLルーティング
 │   │   ├── storage.ts                   # IndexedDB/LocalStorage操作
 │   │   ├── actions/                      # App.svelteから抽出したビジネスロジック
@@ -327,7 +332,7 @@ agasteer/
 
 **GitHub同期:**
 
-- `github.ts`: GitHub API統合（ファイル保存、SHA取得、Git Tree API）
+- `github.ts`: GitHub API統合（ファイル保存、SHA取得、Git Tree API）。純粋層は `github/` 配下へ分離（Phase 1: paths/encoding/sha/rate-limit）。push/pull/http の副作用層は github.ts に残し、純粋関数を re-export して公開 API を維持
 - `sync.ts`: Push/Pull処理の分離
 
 **データ永続化:**

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -8,100 +8,42 @@ import type {
   Note,
   Settings,
   Metadata,
-  WorldType,
   FetchPushCountResult,
   FetchHeadShaResult,
 } from '../types'
 import { PRIORITY_LEAF_ID } from '../utils'
 
 // ============================================
-// パス定数
+// 純粋層（github/ 配下へ分離・Phase 1）
+// ロジック不変・公開 API 維持のため re-export する
 // ============================================
 
-/** Home用パス（通常のノート・リーフ） */
-export const NOTES_PATH = '.agasteer/notes'
-export const NOTES_METADATA_PATH = '.agasteer/notes/metadata.json'
+import {
+  NOTES_PATH,
+  NOTES_METADATA_PATH,
+  ARCHIVE_PATH,
+  ARCHIVE_METADATA_PATH,
+  getBasePath,
+  getMetadataPath,
+  sanitizePathPart,
+  getFolderPath,
+  getNotePath,
+  buildPath,
+} from './github/paths'
+import { parseRateLimitResponse, type RateLimitInfo } from './github/rate-limit'
+import { calculateGitBlobSha } from './github/sha'
+import { encodeContent, decodeBase64ToString } from './github/encoding'
 
-/** Archive用パス */
-export const ARCHIVE_PATH = '.agasteer/archive'
-export const ARCHIVE_METADATA_PATH = '.agasteer/archive/metadata.json'
-
-/**
- * ワールドに応じたベースパスを取得
- */
-export function getBasePath(world: WorldType): string {
-  return world === 'home' ? NOTES_PATH : ARCHIVE_PATH
+export {
+  NOTES_PATH,
+  NOTES_METADATA_PATH,
+  ARCHIVE_PATH,
+  ARCHIVE_METADATA_PATH,
+  getBasePath,
+  getMetadataPath,
+  parseRateLimitResponse,
 }
-
-/**
- * ワールドに応じたメタデータパスを取得
- */
-export function getMetadataPath(world: WorldType): string {
-  return world === 'home' ? NOTES_METADATA_PATH : ARCHIVE_METADATA_PATH
-}
-
-/**
- * レート制限エラー情報
- */
-export interface RateLimitInfo {
-  isRateLimited: boolean
-  resetTime?: Date
-  remainingSeconds?: number
-}
-
-/**
- * レスポンスからレート制限情報を抽出
- */
-export function parseRateLimitResponse(response: Response): RateLimitInfo {
-  if (response.status !== 403 && response.status !== 429) {
-    return { isRateLimited: false }
-  }
-
-  // X-RateLimit-Remaining が 0 の場合はレートリミット確定
-  const remainingHeader = response.headers.get('X-RateLimit-Remaining')
-  const isRateLimited = remainingHeader === '0' || response.status === 429
-
-  if (!isRateLimited) {
-    // 403だがレートリミットではない（権限エラーなど）
-    return { isRateLimited: false }
-  }
-
-  const resetHeader = response.headers.get('X-RateLimit-Reset')
-  if (resetHeader) {
-    const resetTimestamp = parseInt(resetHeader, 10) * 1000 // 秒→ミリ秒
-    const resetTime = new Date(resetTimestamp)
-    const remainingSeconds = Math.max(0, Math.ceil((resetTimestamp - Date.now()) / 1000))
-    return {
-      isRateLimited: true,
-      resetTime,
-      remainingSeconds,
-    }
-  }
-
-  // ヘッダーがない場合（Secondary rate limitなど）
-  // GitHubのドキュメントによると通常1分程度で解除される
-  return { isRateLimited: true, remainingSeconds: 60 }
-}
-
-/**
- * Git blob形式のSHA-1を計算
- * Git仕様: sha1("blob " + UTF-8バイト数 + "\0" + content)
- */
-async function calculateGitBlobSha(content: string): Promise<string> {
-  const encoder = new TextEncoder()
-  const contentBytes = encoder.encode(content)
-  const header = `blob ${contentBytes.length}\0`
-  const headerBytes = encoder.encode(header)
-
-  // headerとcontentを結合
-  const data = new Uint8Array(headerBytes.length + contentBytes.length)
-  data.set(headerBytes, 0)
-  data.set(contentBytes, headerBytes.length)
-
-  const hashBuffer = await crypto.subtle.digest('SHA-1', data)
-  const hashArray = Array.from(new Uint8Array(hashBuffer))
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
-}
+export type { RateLimitInfo }
 
 export interface SaveResult {
   success: boolean
@@ -244,61 +186,6 @@ async function fetchGitHubContents(
   return fetch(url, {
     headers,
   })
-}
-
-/**
- * UTF-8テキストをBase64エンコード
- */
-function encodeContent(content: string): string {
-  const encoder = new TextEncoder()
-  const bytes = encoder.encode(content)
-  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('')
-  return btoa(binary)
-}
-
-function decodeBase64ToString(base64: string): string {
-  const clean = base64.replace(/\n/g, '')
-  const binary = atob(clean)
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i)
-  }
-  return new TextDecoder().decode(bytes)
-}
-
-/**
- * ノートパスを構築
- */
-function getFolderPath(note: Note, allNotes: Note[]): string {
-  const parentNote = note.parentId ? allNotes.find((f) => f.id === note.parentId) : null
-
-  if (parentNote) {
-    return `${parentNote.name}/${note.name}`
-  }
-  return note.name
-}
-
-/**
- * ノートのフルパスを取得（.agasteer/notes/または.agasteer/archive/配下のディレクトリパス）
- */
-function getNotePath(note: Note, allNotes: Note[], world: WorldType = 'home'): string {
-  const basePath = getBasePath(world)
-  return `${basePath}/${getFolderPath(note, allNotes)}`
-}
-
-function buildPath(leaf: Leaf, notes: Note[], world: WorldType = 'home'): string {
-  const note = notes.find((f) => f.id === leaf.noteId)
-  const basePath = getBasePath(world)
-  // ファイル名に使えない文字をサニタイズ
-  const sanitizedTitle = sanitizePathPart(leaf.title)
-  if (!note) {
-    console.warn('[buildPath] Note not found for leaf:', leaf.title, 'noteId:', leaf.noteId)
-    return `${basePath}/${sanitizedTitle}.md`
-  }
-
-  const folderPath = getFolderPath(note, notes)
-  const path = `${basePath}/${folderPath}/${sanitizedTitle}.md`
-  return path
 }
 
 /**
@@ -1764,18 +1651,6 @@ export async function testGitHubConnection(settings: Settings): Promise<TestResu
     console.error('GitHub test error:', error)
     return { success: false, message: 'github.networkError', errorCode: 'E-3009' }
   }
-}
-const sanitizePathPart = (raw: string): string => {
-  const cleaned = raw.replace(/[\\/:*?"<>|#]/g, '-').replace(/\s+/g, ' ')
-  const limited = cleaned.slice(0, 80)
-  return limited.length === 0 ? 'Untitled' : limited
-}
-
-const collapseToTwoLevels = (parts: string[]): string[] => {
-  if (parts.length <= 2) return parts
-  const first = sanitizePathPart(parts[0])
-  const second = sanitizePathPart(parts.slice(1).join('/'))
-  return [first, second]
 }
 
 /**

--- a/src/lib/api/github/encoding.test.ts
+++ b/src/lib/api/github/encoding.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { encodeContent, decodeBase64ToString } from './encoding'
+
+describe('encodeContent', () => {
+  it('encodes ASCII to base64', () => {
+    // "hello" -> known base64
+    expect(encodeContent('hello')).toBe('aGVsbG8=')
+  })
+
+  it('encodes an empty string to an empty base64 string', () => {
+    expect(encodeContent('')).toBe('')
+  })
+
+  it('encodes multibyte UTF-8 (Japanese) correctly', () => {
+    // "あ" (U+3042) is E3 81 82 in UTF-8 -> base64 "44GC"
+    expect(encodeContent('あ')).toBe('44GC')
+  })
+
+  it('encodes an emoji (surrogate pair) correctly', () => {
+    // "😀" (U+1F600) is F0 9F 98 80 -> base64 "8J+YgA=="
+    expect(encodeContent('😀')).toBe('8J+YgA==')
+  })
+})
+
+describe('decodeBase64ToString', () => {
+  it('decodes base64 back to ASCII', () => {
+    expect(decodeBase64ToString('aGVsbG8=')).toBe('hello')
+  })
+
+  it('decodes multibyte UTF-8 (Japanese) correctly', () => {
+    expect(decodeBase64ToString('44GC')).toBe('あ')
+  })
+
+  it('ignores embedded newlines (GitHub-style wrapped base64)', () => {
+    // GitHub Contents API returns base64 with \n line wraps
+    expect(decodeBase64ToString('aGVs\nbG8=\n')).toBe('hello')
+  })
+})
+
+describe('encode/decode round trip', () => {
+  it('survives a round trip for mixed content', () => {
+    const samples = [
+      '',
+      'plain ascii',
+      'マークダウン # 見出し\n- リスト',
+      '😀🎉 emoji and ascii mix',
+      'line1\nline2\r\nline3\ttab',
+    ]
+    for (const sample of samples) {
+      expect(decodeBase64ToString(encodeContent(sample))).toBe(sample)
+    }
+  })
+})

--- a/src/lib/api/github/encoding.ts
+++ b/src/lib/api/github/encoding.ts
@@ -1,0 +1,29 @@
+/**
+ * Base64 / UTF-8 エンコード変換（純粋層）
+ *
+ * 文字列 ↔ Base64 の純粋変換。fetch・settings・IO に触れない。
+ * github.ts から純移動（Phase 1）。振る舞いは不変。
+ */
+
+/**
+ * UTF-8テキストをBase64エンコード
+ */
+export function encodeContent(content: string): string {
+  const encoder = new TextEncoder()
+  const bytes = encoder.encode(content)
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('')
+  return btoa(binary)
+}
+
+/**
+ * Base64文字列をUTF-8テキストにデコード（改行は除去）
+ */
+export function decodeBase64ToString(base64: string): string {
+  const clean = base64.replace(/\n/g, '')
+  const binary = atob(clean)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return new TextDecoder().decode(bytes)
+}

--- a/src/lib/api/github/paths.test.ts
+++ b/src/lib/api/github/paths.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Leaf, Note } from '../../types'
+import {
+  NOTES_PATH,
+  NOTES_METADATA_PATH,
+  ARCHIVE_PATH,
+  ARCHIVE_METADATA_PATH,
+  getBasePath,
+  getMetadataPath,
+  sanitizePathPart,
+  getFolderPath,
+  getNotePath,
+  buildPath,
+} from './paths'
+
+function makeNote(partial: Partial<Note> & { id: string; name: string }): Note {
+  return { order: 0, ...partial }
+}
+
+function makeLeaf(partial: Partial<Leaf> & { noteId: string; title: string }): Leaf {
+  return { id: 'leaf-id', content: '', updatedAt: 0, order: 0, ...partial }
+}
+
+describe('path constants', () => {
+  it('home base path / metadata path', () => {
+    expect(NOTES_PATH).toBe('.agasteer/notes')
+    expect(NOTES_METADATA_PATH).toBe('.agasteer/notes/metadata.json')
+    expect(NOTES_METADATA_PATH).toBe(`${NOTES_PATH}/metadata.json`)
+  })
+
+  it('archive base path / metadata path', () => {
+    expect(ARCHIVE_PATH).toBe('.agasteer/archive')
+    expect(ARCHIVE_METADATA_PATH).toBe('.agasteer/archive/metadata.json')
+    expect(ARCHIVE_METADATA_PATH).toBe(`${ARCHIVE_PATH}/metadata.json`)
+  })
+})
+
+describe('getBasePath / getMetadataPath', () => {
+  it('home world resolves to notes paths', () => {
+    expect(getBasePath('home')).toBe(NOTES_PATH)
+    expect(getMetadataPath('home')).toBe(NOTES_METADATA_PATH)
+  })
+
+  it('archive world resolves to archive paths', () => {
+    expect(getBasePath('archive')).toBe(ARCHIVE_PATH)
+    expect(getMetadataPath('archive')).toBe(ARCHIVE_METADATA_PATH)
+  })
+})
+
+describe('sanitizePathPart', () => {
+  it('replaces filesystem-unsafe characters with hyphen', () => {
+    expect(sanitizePathPart('a/b\\c:d*e?f"g<h>i|j#k')).toBe('a-b-c-d-e-f-g-h-i-j-k')
+  })
+
+  it('collapses runs of whitespace to a single space', () => {
+    expect(sanitizePathPart('hello   world\t\nfoo')).toBe('hello world foo')
+  })
+
+  it('limits length to 80 characters', () => {
+    const long = 'x'.repeat(200)
+    expect(sanitizePathPart(long)).toHaveLength(80)
+  })
+
+  it('returns "Untitled" when the result is empty', () => {
+    expect(sanitizePathPart('')).toBe('Untitled')
+    // whitespace-only collapses to a single space (length 1), not empty
+    expect(sanitizePathPart('   ')).toBe(' ')
+  })
+
+  it('leaves a normal title untouched', () => {
+    expect(sanitizePathPart('My Note 2026')).toBe('My Note 2026')
+  })
+})
+
+describe('getFolderPath', () => {
+  const notes: Note[] = [
+    makeNote({ id: 'parent', name: 'Parent' }),
+    makeNote({ id: 'child', name: 'Child', parentId: 'parent' }),
+  ]
+
+  it('returns the note name for a root note', () => {
+    expect(getFolderPath(notes[0], notes)).toBe('Parent')
+  })
+
+  it('prefixes the parent name for a child note', () => {
+    expect(getFolderPath(notes[1], notes)).toBe('Parent/Child')
+  })
+
+  it('falls back to the bare name when the parent is missing', () => {
+    const orphan = makeNote({ id: 'orphan', name: 'Orphan', parentId: 'nope' })
+    expect(getFolderPath(orphan, notes)).toBe('Orphan')
+  })
+})
+
+describe('getNotePath', () => {
+  const notes: Note[] = [
+    makeNote({ id: 'parent', name: 'Parent' }),
+    makeNote({ id: 'child', name: 'Child', parentId: 'parent' }),
+  ]
+
+  it('prefixes the home base path', () => {
+    expect(getNotePath(notes[1], notes, 'home')).toBe('.agasteer/notes/Parent/Child')
+  })
+
+  it('prefixes the archive base path', () => {
+    expect(getNotePath(notes[1], notes, 'archive')).toBe('.agasteer/archive/Parent/Child')
+  })
+
+  it('defaults to home when world is omitted', () => {
+    expect(getNotePath(notes[0], notes)).toBe('.agasteer/notes/Parent')
+  })
+})
+
+describe('buildPath', () => {
+  const notes: Note[] = [
+    makeNote({ id: 'parent', name: 'Parent' }),
+    makeNote({ id: 'child', name: 'Child', parentId: 'parent' }),
+  ]
+
+  it('builds a full .md path under the note folder', () => {
+    const leaf = makeLeaf({ noteId: 'child', title: 'Hello' })
+    expect(buildPath(leaf, notes, 'home')).toBe('.agasteer/notes/Parent/Child/Hello.md')
+  })
+
+  it('sanitizes the title in the file name', () => {
+    const leaf = makeLeaf({ noteId: 'parent', title: 'a/b:c' })
+    expect(buildPath(leaf, notes, 'home')).toBe('.agasteer/notes/Parent/a-b-c.md')
+  })
+
+  it('uses the archive base path for the archive world', () => {
+    const leaf = makeLeaf({ noteId: 'parent', title: 'Hello' })
+    expect(buildPath(leaf, notes, 'archive')).toBe('.agasteer/archive/Parent/Hello.md')
+  })
+
+  it('falls back to base path + title when the note is not found', () => {
+    const leaf = makeLeaf({ noteId: 'missing', title: 'Orphan' })
+    expect(buildPath(leaf, notes, 'home')).toBe('.agasteer/notes/Orphan.md')
+  })
+})

--- a/src/lib/api/github/paths.ts
+++ b/src/lib/api/github/paths.ts
@@ -1,0 +1,81 @@
+/**
+ * GitHub 同期のパス構築（純粋層）
+ *
+ * fetch・settings・IO に一切触れない純粋関数・定数のみを置く。
+ * github.ts から純移動（Phase 1）。振る舞いは不変。
+ */
+
+import type { Leaf, Note, WorldType } from '../../types'
+
+// ============================================
+// パス定数
+// ============================================
+
+/** Home用パス（通常のノート・リーフ） */
+export const NOTES_PATH = '.agasteer/notes'
+export const NOTES_METADATA_PATH = '.agasteer/notes/metadata.json'
+
+/** Archive用パス */
+export const ARCHIVE_PATH = '.agasteer/archive'
+export const ARCHIVE_METADATA_PATH = '.agasteer/archive/metadata.json'
+
+/**
+ * ワールドに応じたベースパスを取得
+ */
+export function getBasePath(world: WorldType): string {
+  return world === 'home' ? NOTES_PATH : ARCHIVE_PATH
+}
+
+/**
+ * ワールドに応じたメタデータパスを取得
+ */
+export function getMetadataPath(world: WorldType): string {
+  return world === 'home' ? NOTES_METADATA_PATH : ARCHIVE_METADATA_PATH
+}
+
+/**
+ * ファイル名・ノート名に使えない文字をサニタイズし、80文字に制限する
+ */
+export function sanitizePathPart(raw: string): string {
+  const cleaned = raw.replace(/[\\/:*?"<>|#]/g, '-').replace(/\s+/g, ' ')
+  const limited = cleaned.slice(0, 80)
+  return limited.length === 0 ? 'Untitled' : limited
+}
+
+/**
+ * ノートパスを構築
+ */
+export function getFolderPath(note: Note, allNotes: Note[]): string {
+  const parentNote = note.parentId ? allNotes.find((f) => f.id === note.parentId) : null
+
+  if (parentNote) {
+    return `${parentNote.name}/${note.name}`
+  }
+  return note.name
+}
+
+/**
+ * ノートのフルパスを取得（.agasteer/notes/または.agasteer/archive/配下のディレクトリパス）
+ */
+export function getNotePath(note: Note, allNotes: Note[], world: WorldType = 'home'): string {
+  const basePath = getBasePath(world)
+  return `${basePath}/${getFolderPath(note, allNotes)}`
+}
+
+/**
+ * リーフのフルパス（.md ファイル）を構築
+ */
+export function buildPath(leaf: Leaf, notes: Note[], world: WorldType = 'home'): string {
+  const note = notes.find((f) => f.id === leaf.noteId)
+  const basePath = getBasePath(world)
+  // ファイル名に使えない文字をサニタイズ
+  const sanitizedTitle = sanitizePathPart(leaf.title)
+  if (!note) {
+    console.warn('[buildPath] Note not found for leaf:', leaf.title, 'noteId:', leaf.noteId)
+    return `${basePath}/${sanitizedTitle}.md`
+  }
+
+  const folderPath = getFolderPath(note, notes)
+  const path = `${basePath}/${folderPath}/${sanitizedTitle}.md`
+  return path
+}

--- a/src/lib/api/github/rate-limit.test.ts
+++ b/src/lib/api/github/rate-limit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+
+import { parseRateLimitResponse } from './rate-limit'
+
+function makeResponse(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(null, { status, headers })
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('parseRateLimitResponse', () => {
+  it('returns not-rate-limited for a 200 response', () => {
+    expect(parseRateLimitResponse(makeResponse(200))).toEqual({ isRateLimited: false })
+  })
+
+  it('treats 403 with remaining > 0 as a permission error, not rate limiting', () => {
+    const res = makeResponse(403, { 'X-RateLimit-Remaining': '50' })
+    expect(parseRateLimitResponse(res)).toEqual({ isRateLimited: false })
+  })
+
+  it('treats 403 with remaining 0 as rate limited and computes reset', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    const resetEpochSeconds = Math.floor(Date.UTC(2026, 0, 1, 0, 1, 0) / 1000) // +60s
+    const res = makeResponse(403, {
+      'X-RateLimit-Remaining': '0',
+      'X-RateLimit-Reset': String(resetEpochSeconds),
+    })
+    const info = parseRateLimitResponse(res)
+    expect(info.isRateLimited).toBe(true)
+    expect(info.remainingSeconds).toBe(60)
+    expect(info.resetTime?.getTime()).toBe(resetEpochSeconds * 1000)
+  })
+
+  it('treats 429 as rate limited even when remaining header is absent', () => {
+    const info = parseRateLimitResponse(makeResponse(429))
+    expect(info.isRateLimited).toBe(true)
+    // no reset header -> defaults to 60s secondary-limit fallback
+    expect(info.remainingSeconds).toBe(60)
+    expect(info.resetTime).toBeUndefined()
+  })
+
+  it('clamps remainingSeconds to 0 when the reset time is in the past', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    const pastReset = Math.floor(Date.UTC(2026, 0, 1, 0, 0, 0) / 1000) // 60s ago
+    const res = makeResponse(429, {
+      'X-RateLimit-Remaining': '0',
+      'X-RateLimit-Reset': String(pastReset),
+    })
+    const info = parseRateLimitResponse(res)
+    expect(info.isRateLimited).toBe(true)
+    expect(info.remainingSeconds).toBe(0)
+  })
+})

--- a/src/lib/api/github/rate-limit.ts
+++ b/src/lib/api/github/rate-limit.ts
@@ -1,0 +1,49 @@
+/**
+ * GitHub レート制限の解析（純粋層）
+ *
+ * Response からヘッダを読むだけの純粋変換。fetch しない。
+ * github.ts から純移動（Phase 1）。振る舞いは不変。
+ */
+
+/**
+ * レート制限エラー情報
+ */
+export interface RateLimitInfo {
+  isRateLimited: boolean
+  resetTime?: Date
+  remainingSeconds?: number
+}
+
+/**
+ * レスポンスからレート制限情報を抽出
+ */
+export function parseRateLimitResponse(response: Response): RateLimitInfo {
+  if (response.status !== 403 && response.status !== 429) {
+    return { isRateLimited: false }
+  }
+
+  // X-RateLimit-Remaining が 0 の場合はレートリミット確定
+  const remainingHeader = response.headers.get('X-RateLimit-Remaining')
+  const isRateLimited = remainingHeader === '0' || response.status === 429
+
+  if (!isRateLimited) {
+    // 403だがレートリミットではない（権限エラーなど）
+    return { isRateLimited: false }
+  }
+
+  const resetHeader = response.headers.get('X-RateLimit-Reset')
+  if (resetHeader) {
+    const resetTimestamp = parseInt(resetHeader, 10) * 1000 // 秒→ミリ秒
+    const resetTime = new Date(resetTimestamp)
+    const remainingSeconds = Math.max(0, Math.ceil((resetTimestamp - Date.now()) / 1000))
+    return {
+      isRateLimited: true,
+      resetTime,
+      remainingSeconds,
+    }
+  }
+
+  // ヘッダーがない場合（Secondary rate limitなど）
+  // GitHubのドキュメントによると通常1分程度で解除される
+  return { isRateLimited: true, remainingSeconds: 60 }
+}

--- a/src/lib/api/github/sha.test.ts
+++ b/src/lib/api/github/sha.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateGitBlobSha } from './sha'
+
+// 期待値は `git hash-object --stdin` で算出した既知の Git blob SHA-1。
+// Git 仕様: sha1("blob " + UTF-8バイト数 + "\0" + content)
+describe('calculateGitBlobSha', () => {
+  it('matches git for an empty string', async () => {
+    expect(await calculateGitBlobSha('')).toBe('e69de29bb2d1d6434b8b29ae775ad8c2e48c5391')
+  })
+
+  it('matches git for "hello"', async () => {
+    expect(await calculateGitBlobSha('hello')).toBe('b6fc4c620b67d95f953a5c1c1230aaab5db5a1b0')
+  })
+
+  it('matches git for "hello\\n" (trailing newline changes the hash)', async () => {
+    expect(await calculateGitBlobSha('hello\n')).toBe('ce013625030ba8dba906f756967f9e9ca394464a')
+  })
+
+  it('matches git for a multibyte UTF-8 string (byte length, not char length)', async () => {
+    // "あ" is 3 UTF-8 bytes -> header "blob 3\0"
+    expect(await calculateGitBlobSha('あ')).toBe('0575c798f05a90ca8b3617062cd61648221d8a63')
+  })
+
+  it('produces a 40-character lowercase hex digest', async () => {
+    const sha = await calculateGitBlobSha('arbitrary content')
+    expect(sha).toMatch(/^[0-9a-f]{40}$/)
+  })
+
+  it('is deterministic for the same input', async () => {
+    const a = await calculateGitBlobSha('same input')
+    const b = await calculateGitBlobSha('same input')
+    expect(a).toBe(b)
+  })
+})

--- a/src/lib/api/github/sha.ts
+++ b/src/lib/api/github/sha.ts
@@ -1,0 +1,26 @@
+/**
+ * Git blob SHA 計算（純粋層）
+ *
+ * 文字列 → ハッシュの純粋関数。fetch・settings・IO に触れない。
+ * github.ts から純移動（Phase 1）。振る舞いは不変。
+ */
+
+/**
+ * Git blob形式のSHA-1を計算
+ * Git仕様: sha1("blob " + UTF-8バイト数 + "\0" + content)
+ */
+export async function calculateGitBlobSha(content: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const contentBytes = encoder.encode(content)
+  const header = `blob ${contentBytes.length}\0`
+  const headerBytes = encoder.encode(header)
+
+  // headerとcontentを結合
+  const data = new Uint8Array(headerBytes.length + contentBytes.length)
+  data.set(headerBytes, 0)
+  data.set(contentBytes, headerBytes.length)
+
+  const hashBuffer = await crypto.subtle.digest('SHA-1', data)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+}


### PR DESCRIPTION
Refs #226

## Phase 1: 純粋層のみ・振る舞い不変・公開API同一

github.ts（2164行）の純粋関数・定数だけを `src/lib/api/github/` 配下へ純移動し、github.ts から re-export して公開 API を完全に維持する。push/pull/http の副作用層・巨大関数は触らない（別フェーズ）。

### 変更概要
- **判定基準**: fetch・settings（トークン）・ネットワーク/IndexedDB に触れない関数だけを移動。曖昧なものは保守的に github.ts に残置。
- **新モジュール**（純移動・ロジック不変）:
  - `github/paths.ts`: `NOTES_PATH`/`NOTES_METADATA_PATH`/`ARCHIVE_PATH`/`ARCHIVE_METADATA_PATH`、`getBasePath`/`getMetadataPath`/`sanitizePathPart`/`getFolderPath`/`getNotePath`/`buildPath`
  - `github/encoding.ts`: `encodeContent`/`decodeBase64ToString`
  - `github/sha.ts`: `calculateGitBlobSha`
  - `github/rate-limit.ts`: `parseRateLimitResponse`/`RateLimitInfo`
- github.ts は新モジュールから import して内部利用し、従来 export していたシンボル（`NOTES_PATH` 等・`getBasePath`/`getMetadataPath`/`parseRateLimitResponse`/`RateLimitInfo`）を re-export。importer（`api/index.ts`・`routing.ts` 等）は不変。
- 移動に伴い github.ts 内で重複していた module-level の `sanitizePathPart` と未使用の `collapseToTwoLevels`（各 pull 関数はローカル定義を使用）を除去。未使用になった `WorldType` 型 import も削除。

### テスト
- 各純粋モジュールに単体テストを新設（合計 +38件）:
  - paths.test.ts 19件（パス定数・base/metadata 解決・サニタイズ境界・folder/note/buildPath 入出力・ノート欠落フォールバック）
  - encoding.test.ts 8件（ASCII/日本語/絵文字の base64 と往復）
  - sha.test.ts 6件（`git hash-object` 既知値一致・空/改行/マルチバイト・40桁hex・決定性）
  - rate-limit.test.ts 5件（200/403権限/403レート/429/過去resetのクランプ）
- `npm test`: 159 passed（既存 121 不変 + 新規 38）
- `npm run lint`: prettier --check OK / svelte-check 0 errors 0 warnings
- github.ts 行数: 2164 → 2039

### 副作用層は未着手（確認）
push/pull/http/fetch 系（`pushAllWithTreeAPI`/`pullFromGitHub`/`pullArchive`/`testGitHubConnection`/`fetchRemoteHeadSha`/`fetchRemotePushCount`/`fetchCurrentSha`/`saveToGitHub`/`fetchGitHubContents`/`validateGitHubSettings`/`runWithConcurrency`）は1つも移動・変更していない。