### PR TITLE
test: characterization tests for github push/status sync layer (#231 wave A)

### DIFF
--- a/src/lib/api/github/__tests__/fetch-mock.ts
+++ b/src/lib/api/github/__tests__/fetch-mock.ts
@@ -1,0 +1,220 @@
+/**
+ * fetch モック基盤（characterization テスト用・#231）
+ *
+ * 本番コードには一切手を入れず、`fetch` を差し替えて GitHub API の応答を
+ * URL + method でマッチ・順番に消費（キュー）する仕組みを提供する。
+ * Wave A（push/status）と Wave B（pull）の両方から再利用できる。
+ *
+ * 使い方の要点:
+ *  - `createFetchMock()` で mock を作り、`vi.stubGlobal('fetch', mock.fn)` で差し込む。
+ *  - `mock.on(method, urlMatcher, response)` で 1 リクエスト分の応答を**キュー**する。
+ *    同じ matcher を複数回 on すると、呼ばれた順に消費される（段階応答）。
+ *  - matcher は文字列（完全一致 or 部分一致）・正規表現・述語関数のいずれか。
+ *  - 応答は {status, json, text, headers} を持つ簡易記述。`json` があれば JSON 化、
+ *    `text` があればそのまま本文にする。
+ *  - 記録された全リクエストは `mock.calls` で参照でき、URL・method・body(JSON)・headers を
+ *    assert できる。
+ *
+ * GitHub Contents API はキャッシュバスター `?t=<Date.now()>` を URL に付けるため、
+ * matcher は基本「URL に含まれるか（部分一致）」で書く。
+ */
+
+import { vi } from 'vitest'
+
+export interface MockResponseSpec {
+  status?: number
+  /** JSON 本文（指定すると application/json で返す） */
+  json?: unknown
+  /** テキスト本文（raw コンテンツ取得用） */
+  text?: string
+  /** レスポンスヘッダ（rate-limit ヘッダ等） */
+  headers?: Record<string, string>
+}
+
+export type UrlMatcher = string | RegExp | ((url: string) => boolean)
+
+export interface RecordedCall {
+  url: string
+  method: string
+  headers: Record<string, string>
+  /** リクエストボディの生文字列（あれば） */
+  rawBody?: string
+  /** リクエストボディを JSON.parse した結果（パースできた場合のみ） */
+  body?: any
+  /** fetch の第2引数 init.cache */
+  cache?: string
+}
+
+interface QueuedResponse {
+  method: string
+  matcher: UrlMatcher
+  spec: MockResponseSpec
+}
+
+function urlMatches(matcher: UrlMatcher, url: string): boolean {
+  if (typeof matcher === 'function') return matcher(url)
+  if (matcher instanceof RegExp) return matcher.test(url)
+  // 文字列は「部分一致」で扱う（キャッシュバスター付き URL に対応するため）
+  return url.includes(matcher)
+}
+
+function specToResponse(spec: MockResponseSpec): Response {
+  const status = spec.status ?? 200
+  const headers = new Headers(spec.headers ?? {})
+  let bodyStr: string | null = null
+  if (spec.json !== undefined) {
+    bodyStr = JSON.stringify(spec.json)
+    if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json')
+  } else if (spec.text !== undefined) {
+    bodyStr = spec.text
+  }
+  // 204/205/304 は body 不可なので null にする
+  const noBodyStatuses = [204, 205, 304]
+  const body = noBodyStatuses.includes(status) ? null : bodyStr
+  return new Response(body, { status, headers })
+}
+
+export interface FetchMock {
+  /** vi.stubGlobal('fetch', mock.fn) で差し込む関数 */
+  fn: ReturnType<typeof vi.fn>
+  /** 1 リクエスト分の応答をキューする（同 matcher 複数回 = 段階応答） */
+  on: (method: string, matcher: UrlMatcher, spec: MockResponseSpec) => FetchMock
+  /** 記録された全リクエスト */
+  calls: RecordedCall[]
+  /** method + matcher にマッチした記録だけを返す */
+  callsMatching: (method: string, matcher: UrlMatcher) => RecordedCall[]
+  /** 最初にマッチした記録 */
+  firstCall: (method: string, matcher: UrlMatcher) => RecordedCall | undefined
+}
+
+export function createFetchMock(): FetchMock {
+  const queue: QueuedResponse[] = []
+  const calls: RecordedCall[] = []
+
+  const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method ?? 'GET').toUpperCase()
+
+    // ヘッダを Record に正規化
+    const headers: Record<string, string> = {}
+    const rawHeaders = init?.headers
+    if (rawHeaders) {
+      if (rawHeaders instanceof Headers) {
+        rawHeaders.forEach((v, k) => {
+          headers[k] = v
+        })
+      } else if (Array.isArray(rawHeaders)) {
+        for (const [k, v] of rawHeaders) headers[k] = v
+      } else {
+        Object.assign(headers, rawHeaders)
+      }
+    }
+
+    const rawBody = typeof init?.body === 'string' ? init.body : undefined
+    let body: any
+    if (rawBody !== undefined) {
+      try {
+        body = JSON.parse(rawBody)
+      } catch {
+        body = undefined
+      }
+    }
+
+    calls.push({
+      url,
+      method,
+      headers,
+      rawBody,
+      body,
+      cache: (init as any)?.cache,
+    })
+
+    // キューから最初にマッチするものを探して消費する
+    const idx = queue.findIndex(
+      (q) => q.method.toUpperCase() === method && urlMatches(q.matcher, url)
+    )
+    if (idx === -1) {
+      throw new Error(
+        `[fetch-mock] no queued response for ${method} ${url}\n` +
+          `remaining queue: ${queue.map((q) => `${q.method} ${String(q.matcher)}`).join(', ') || '(empty)'}`
+      )
+    }
+    const [matched] = queue.splice(idx, 1)
+    return specToResponse(matched.spec)
+  })
+
+  const mock: FetchMock = {
+    fn,
+    calls,
+    on(method, matcher, spec) {
+      queue.push({ method, matcher, spec })
+      return mock
+    },
+    callsMatching(method, matcher) {
+      return calls.filter(
+        (c) => c.method.toUpperCase() === method.toUpperCase() && urlMatches(matcher, c.url)
+      )
+    },
+    firstCall(method, matcher) {
+      return mock.callsMatching(method, matcher)[0]
+    },
+  }
+  return mock
+}
+
+// ============================================
+// テスト用のダミーデータ生成ヘルパー
+// ============================================
+
+import type { Settings, Leaf, Note, Metadata } from '../../../types'
+
+export function makeSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    token: 'test-token',
+    repoName: 'owner/repo',
+    theme: 'light' as Settings['theme'],
+    toolName: 'agasteer',
+    locale: 'ja' as Settings['locale'],
+    ...overrides,
+  }
+}
+
+export function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: overrides.id ?? 'note-1',
+    name: overrides.name ?? 'Note',
+    parentId: overrides.parentId,
+    order: overrides.order ?? 0,
+    badgeIcon: overrides.badgeIcon,
+    badgeColor: overrides.badgeColor,
+  }
+}
+
+export function makeLeaf(overrides: Partial<Leaf> = {}): Leaf {
+  return {
+    id: overrides.id ?? 'leaf-1',
+    title: overrides.title ?? 'Leaf',
+    noteId: overrides.noteId ?? 'note-1',
+    content: overrides.content ?? 'hello world',
+    updatedAt: overrides.updatedAt ?? 1000,
+    order: overrides.order ?? 0,
+    badgeIcon: overrides.badgeIcon,
+    badgeColor: overrides.badgeColor,
+    blobSha: overrides.blobSha,
+  }
+}
+
+export function makeMetadata(overrides: Partial<Metadata> = {}): Metadata {
+  return {
+    version: 1,
+    notes: {},
+    leaves: {},
+    pushCount: 0,
+    ...overrides,
+  }
+}
+
+/** base64 エンコード（GitHub Contents API / Blob API レスポンス用） */
+export function b64(s: string): string {
+  return Buffer.from(s, 'utf-8').toString('base64')
+}

--- a/src/lib/api/github/__tests__/github-push.characterization.test.ts
+++ b/src/lib/api/github/__tests__/github-push.characterization.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Characterization テスト（#231 Wave A）— pushAllWithTreeAPI
+ *
+ * 対象: pushAllWithTreeAPI（blob/tree/commit/ref の GitHub Git Data API シーケンス）
+ *
+ * 本番コードは変更しない。現状の API 呼び出し列・リクエストボディ・差分判定・
+ * 各エラー分岐を fetch モックで観測して golden master に固定する。
+ *
+ * シーケンス（既存リポ・変更ありの golden path）:
+ *   1. GET  /repos/{repo}                      -> default_branch
+ *   2. GET  /git/ref/heads/{branch}            -> object.sha (HEAD commit)
+ *   3. GET  /git/commits/{sha}                 -> tree.sha (base tree)
+ *   4. GET  /git/trees/{baseTreeSha}?recursive=1 -> 既存ファイル一覧
+ *   5. (既存 metadata.json があれば) GET /git/blobs/{sha} -> pushCount
+ *   6. POST /git/trees                         -> 新 tree sha
+ *   7. POST /git/commits                       -> 新 commit sha
+ *   8. PATCH /git/refs/heads/{branch}          -> ref 更新
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+
+import {
+  createFetchMock,
+  makeSettings,
+  makeNote,
+  makeLeaf,
+  b64,
+  type FetchMock,
+} from './fetch-mock'
+
+// localStorage スタブ → 動的 import（github-status 側と同じ理由）
+const storageBacking = new Map<string, string>()
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => storageBacking.get(k) ?? null,
+  setItem: (k: string, v: string) => void storageBacking.set(k, v),
+  removeItem: (k: string) => void storageBacking.delete(k),
+  clear: () => storageBacking.clear(),
+  key: (i: number) => Array.from(storageBacking.keys())[i] ?? null,
+  get length() {
+    return storageBacking.size
+  },
+}
+
+const { pushAllWithTreeAPI } = await import('../../github')
+const { calculateGitBlobSha } = await import('../sha')
+
+let mock: FetchMock
+
+beforeEach(() => {
+  mock = createFetchMock()
+  vi.stubGlobal('fetch', mock.fn)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+const REPO = 'https://api.github.com/repos/owner/repo'
+
+/** 既存リポの 1〜4 段（repo/ref/commit/tree）を仕込む共通ヘルパ */
+function stageExistingRepo(opts: {
+  branch?: string
+  headSha?: string
+  baseTreeSha?: string
+  treeEntries?: Array<{ path: string; mode?: string; type?: string; sha: string }>
+  truncated?: boolean
+}) {
+  const branch = opts.branch ?? 'main'
+  const headSha = opts.headSha ?? 'head-commit-sha'
+  const baseTreeSha = opts.baseTreeSha ?? 'base-tree-sha'
+  mock
+    .on('GET', REPO, { json: { default_branch: branch } })
+    .on('GET', `/git/ref/heads/${branch}`, { json: { object: { sha: headSha } } })
+    .on('GET', `/git/commits/${headSha}`, { json: { tree: { sha: baseTreeSha } } })
+    .on('GET', `/git/trees/${baseTreeSha}?recursive=1`, {
+      json: {
+        truncated: opts.truncated ?? false,
+        tree: (opts.treeEntries ?? []).map((e) => ({
+          path: e.path,
+          mode: e.mode ?? '100644',
+          type: e.type ?? 'blob',
+          sha: e.sha,
+        })),
+      },
+    })
+  return { branch, headSha, baseTreeSha }
+}
+
+/** 6〜8 段（new tree / new commit / patch ref）を仕込む共通ヘルパ */
+function stageWriteSequence(opts: { branch?: string; newTreeSha?: string; newCommitSha?: string }) {
+  const branch = opts.branch ?? 'main'
+  mock
+    .on('POST', '/git/trees', { json: { sha: opts.newTreeSha ?? 'new-tree-sha' } })
+    .on('POST', '/git/commits', { json: { sha: opts.newCommitSha ?? 'new-commit-sha' } })
+    .on('PATCH', `/git/refs/heads/${branch}`, { json: { ref: `refs/heads/${branch}` } })
+}
+
+const notes = [makeNote({ id: 'note-1', name: 'MyNote' })]
+const leaf = makeLeaf({ id: 'leaf-1', noteId: 'note-1', title: 'MyLeaf', content: 'fresh content' })
+
+// ============================================
+// バリデーション
+// ============================================
+describe('pushAllWithTreeAPI: validation', () => {
+  it('returns E-1018 before any fetch when settings invalid', async () => {
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings({ token: '' }))
+    expect(res.success).toBe(false)
+    expect(res.errorCode).toBe('E-1018')
+    expect(mock.calls).toHaveLength(0)
+  })
+})
+
+// ============================================
+// golden path（既存リポ・初回 push 相当＝metadata 無し・リーフ新規）
+// ============================================
+describe('pushAllWithTreeAPI: golden path (existing repo, changed leaf)', () => {
+  it('walks repo->ref->commit->tree then POST tree, POST commit, PATCH ref', async () => {
+    stageExistingRepo({ treeEntries: [] }) // 空 tree = metadata 無し = 初回相当
+    stageWriteSequence({ newCommitSha: 'commit-XYZ' })
+
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+
+    expect(res.success).toBe(true)
+    expect(res.message).toBe('github.pushOk')
+    expect(res.commitSha).toBe('commit-XYZ')
+    expect(res.changedLeafCount).toBe(1)
+    expect(res.changedArchiveLeafCount).toBe(0)
+    expect(res.metadataOnlyChanged).toBe(false)
+
+    // 呼び出し列の順序と method を pin
+    const seq = mock.calls.map((c) => `${c.method} ${c.url.replace(/\?t=\d+/, '')}`)
+    expect(seq).toEqual([
+      'GET https://api.github.com/repos/owner/repo',
+      'GET https://api.github.com/repos/owner/repo/git/ref/heads/main',
+      'GET https://api.github.com/repos/owner/repo/git/commits/head-commit-sha',
+      'GET https://api.github.com/repos/owner/repo/git/trees/base-tree-sha?recursive=1',
+      'POST https://api.github.com/repos/owner/repo/git/trees',
+      'POST https://api.github.com/repos/owner/repo/git/commits',
+      'PATCH https://api.github.com/repos/owner/repo/git/refs/heads/main',
+    ])
+  })
+
+  it('sends Authorization: Bearer <token> and JSON content-type on the repo fetch', async () => {
+    stageExistingRepo({ treeEntries: [] })
+    stageWriteSequence({})
+    await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    const repoCall = mock.firstCall('GET', REPO)
+    expect(repoCall!.headers.Authorization).toBe('Bearer test-token')
+    expect(repoCall!.headers['Content-Type']).toBe('application/json')
+    // ref/commit/tree は cache: no-store でないものもあるが repo と ref は no-store
+    expect(repoCall!.cache).toBe('no-store')
+    expect(mock.firstCall('GET', '/git/ref/heads/main')!.cache).toBe('no-store')
+  })
+
+  it('POST /git/trees includes leaf content as a blob entry (no base_tree)', async () => {
+    stageExistingRepo({ treeEntries: [] })
+    stageWriteSequence({})
+    await pushAllWithTreeAPI([leaf], notes, makeSettings())
+
+    const treeCall = mock.firstCall('POST', '/git/trees')
+    expect(treeCall).toBeDefined()
+    // base_tree は使わない（全ファイル明示）
+    expect('base_tree' in treeCall!.body).toBe(false)
+    const items: any[] = treeCall!.body.tree
+    const leafItem = items.find((i) => i.path === '.agasteer/notes/MyNote/MyLeaf.md')
+    expect(leafItem).toMatchObject({
+      path: '.agasteer/notes/MyNote/MyLeaf.md',
+      mode: '100644',
+      type: 'blob',
+      content: 'fresh content',
+    })
+    // metadata.json も tree に含まれ、pushCount は 0->1 にインクリメントされる
+    const metaItem = items.find((i) => i.path === '.agasteer/notes/metadata.json')
+    expect(metaItem).toBeDefined()
+    const writtenMeta = JSON.parse(metaItem.content)
+    expect(writtenMeta.pushCount).toBe(1)
+    expect(writtenMeta.leaves['MyNote/MyLeaf.md']).toMatchObject({ id: 'leaf-1', order: 0 })
+    expect(writtenMeta.notes['MyNote']).toMatchObject({ id: 'note-1', order: 0 })
+    // ノートとルートの .gitkeep が含まれる
+    expect(items.some((i) => i.path === '.agasteer/notes/.gitkeep')).toBe(true)
+    expect(items.some((i) => i.path === '.agasteer/notes/MyNote/.gitkeep')).toBe(true)
+  })
+
+  it('POST /git/commits has parents=[HEAD sha], the new tree sha and the agasteer author/committer', async () => {
+    stageExistingRepo({ headSha: 'head-commit-sha', treeEntries: [] })
+    stageWriteSequence({ newTreeSha: 'tree-NEW' })
+    await pushAllWithTreeAPI([leaf], notes, makeSettings())
+
+    const commitCall = mock.firstCall('POST', '/git/commits')
+    expect(commitCall!.body.tree).toBe('tree-NEW')
+    expect(commitCall!.body.parents).toEqual(['head-commit-sha'])
+    expect(commitCall!.body.message).toBe('Agasteer pushed notes')
+    expect(commitCall!.body.author).toEqual({
+      name: 'agasteer',
+      email: 'agasteer@users.noreply.github.com',
+    })
+    expect(commitCall!.body.committer).toEqual({
+      name: 'agasteer',
+      email: 'agasteer@users.noreply.github.com',
+    })
+  })
+
+  it('PATCH ref uses the new commit sha with force:true', async () => {
+    stageExistingRepo({ treeEntries: [] })
+    stageWriteSequence({ newCommitSha: 'commit-NEW' })
+    await pushAllWithTreeAPI([leaf], notes, makeSettings())
+
+    const patchCall = mock.firstCall('PATCH', '/git/refs/heads/main')
+    expect(patchCall!.body).toEqual({ sha: 'commit-NEW', force: true })
+  })
+
+  it('respects a non-default branch name across ref, commit-parent and patch', async () => {
+    stageExistingRepo({ branch: 'develop', treeEntries: [] })
+    stageWriteSequence({ branch: 'develop' })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.success).toBe(true)
+    expect(mock.firstCall('GET', '/git/ref/heads/develop')).toBeDefined()
+    expect(mock.firstCall('PATCH', '/git/refs/heads/develop')).toBeDefined()
+  })
+})
+
+// ============================================
+// 差分判定（変更なし → early return / push スキップ）
+// ============================================
+describe('pushAllWithTreeAPI: no-change short circuit', () => {
+  it('returns github.noChanges and skips tree/commit/ref when nothing changed', async () => {
+    // 既存 tree に、同じ content のリーフ blob と一致する metadata.json を仕込む
+    const leafPath = '.agasteer/notes/MyNote/MyLeaf.md'
+    const leafSha = await calculateGitBlobSha('fresh content')
+    // 既存 metadata はこのリーフ/ノートを既に含む（差分ゼロにするため）
+    const existingMeta = {
+      version: 1,
+      pushCount: 5,
+      notes: { MyNote: { id: 'note-1', order: 0 } },
+      leaves: { 'MyNote/MyLeaf.md': { id: 'leaf-1', updatedAt: 1000, order: 0 } },
+    }
+    const metaSha = 'meta-blob-sha'
+    stageExistingRepo({
+      treeEntries: [
+        { path: leafPath, sha: leafSha },
+        { path: '.agasteer/notes/metadata.json', sha: metaSha },
+      ],
+    })
+    // metadata.json の blob 取得
+    mock.on('GET', `/git/blobs/${metaSha}`, {
+      json: { content: b64(JSON.stringify(existingMeta)) },
+    })
+
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+
+    expect(res.success).toBe(true)
+    expect(res.message).toBe('github.noChanges')
+    expect(res.commitSha).toBe('head-commit-sha')
+    // write 系は一切呼ばれない
+    expect(mock.callsMatching('POST', '/git/trees')).toHaveLength(0)
+    expect(mock.callsMatching('POST', '/git/commits')).toHaveLength(0)
+    expect(mock.callsMatching('PATCH', '/git/refs/heads/main')).toHaveLength(0)
+  })
+
+  it('reuses the existing blob sha (does not resend content) for an unchanged leaf when metadata differs', async () => {
+    // リーフ content は不変だが metadata 差分（pushCount 以外）を作って push を発火させる
+    const leafPath = '.agasteer/notes/MyNote/MyLeaf.md'
+    const leafSha = await calculateGitBlobSha('fresh content')
+    // 既存 metadata はリーフ未登録 → metadata 差分が出る
+    const existingMeta = { version: 1, pushCount: 2, notes: {}, leaves: {} }
+    const metaSha = 'meta-blob-sha2'
+    stageExistingRepo({
+      treeEntries: [
+        { path: leafPath, sha: leafSha },
+        { path: '.agasteer/notes/metadata.json', sha: metaSha },
+      ],
+    })
+    mock.on('GET', `/git/blobs/${metaSha}`, {
+      json: { content: b64(JSON.stringify(existingMeta)) },
+    })
+    stageWriteSequence({})
+
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.success).toBe(true)
+    // リーフ自体は変更なし扱い → changedLeafCount 0、metadataOnlyChanged true
+    expect(res.changedLeafCount).toBe(0)
+    expect(res.metadataOnlyChanged).toBe(true)
+
+    const treeCall = mock.firstCall('POST', '/git/trees')
+    const items: any[] = treeCall!.body.tree
+    const leafItem = items.find((i) => i.path === leafPath)
+    // content ではなく既存 sha を使う
+    expect(leafItem.sha).toBe(leafSha)
+    expect('content' in leafItem).toBe(false)
+    // pushCount は existing(2) + 1 = 3
+    const metaItem = items.find((i) => i.path === '.agasteer/notes/metadata.json')
+    expect(JSON.parse(metaItem.content).pushCount).toBe(3)
+  })
+})
+
+// ============================================
+// 空リポジトリ / 初回 push（ref 404|409）
+// ============================================
+describe('pushAllWithTreeAPI: empty repository', () => {
+  it('initializes via Contents .gitkeep then writes a commit with empty parents', async () => {
+    mock
+      .on('GET', REPO, { json: { default_branch: 'main' } })
+      .on('GET', '/git/ref/heads/main', { status: 409, json: {} })
+      // Contents PUT .gitkeep -> commit + tree sha
+      .on('PUT', '/contents/.gitkeep', {
+        json: { commit: { sha: 'init-commit-sha', tree: { sha: 'init-tree-sha' } } },
+      })
+      // 既存 tree 取得（init-tree-sha） -> 空
+      .on('GET', '/git/trees/init-tree-sha?recursive=1', { json: { truncated: false, tree: [] } })
+    stageWriteSequence({})
+
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.success).toBe(true)
+    expect(res.message).toBe('github.pushOk')
+
+    // 初回コミットは parents が init-commit-sha（Contents API が作ったコミット）
+    const commitCall = mock.firstCall('POST', '/git/commits')
+    expect(commitCall!.body.parents).toEqual(['init-commit-sha'])
+    // .gitkeep 初期化 PUT のボディ
+    const initPut = mock.firstCall('PUT', '/contents/.gitkeep')
+    expect(initPut!.body.message).toBe('Initialize repository')
+    expect(initPut!.body.content).toBe('')
+  })
+
+  it('returns E-1004 when the .gitkeep init PUT fails', async () => {
+    mock
+      .on('GET', REPO, { json: { default_branch: 'main' } })
+      .on('GET', '/git/ref/heads/main', { status: 404, json: {} })
+      .on('PUT', '/contents/.gitkeep', { status: 500, json: {} })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.success).toBe(false)
+    expect(res.errorCode).toBe('E-1004')
+  })
+})
+
+// ============================================
+// rate-limit / error 分岐
+// ============================================
+describe('pushAllWithTreeAPI: rate-limit and error branches', () => {
+  it('returns rateLimited E-1001 when the repo fetch is rate limited (403 remaining 0)', async () => {
+    mock.on('GET', REPO, {
+      status: 403,
+      json: {},
+      headers: { 'X-RateLimit-Remaining': '0' },
+    })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.message).toBe('github.rateLimited')
+    expect(res.errorCode).toBe('E-1001')
+    expect(res.rateLimitInfo?.isRateLimited).toBe(true)
+    expect(res.httpStatus).toBe(403)
+  })
+
+  it('returns repoFetchFailed E-1002 on a non-ok, non-rate-limited repo response (e.g. 403 with quota left = permission)', async () => {
+    mock.on('GET', REPO, {
+      status: 403,
+      json: {},
+      headers: { 'X-RateLimit-Remaining': '50' },
+    })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.message).toBe('github.repoFetchFailed')
+    expect(res.errorCode).toBe('E-1002')
+  })
+
+  it('returns rateLimited E-1003 when the ref fetch is rate limited', async () => {
+    mock.on('GET', REPO, { json: { default_branch: 'main' } }).on('GET', '/git/ref/heads/main', {
+      status: 403,
+      json: {},
+      headers: { 'X-RateLimit-Remaining': '0' },
+    })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.errorCode).toBe('E-1003')
+    expect(res.message).toBe('github.rateLimited')
+  })
+
+  it('returns branchFetchFailed E-1005 on a non-empty, non-ok ref response', async () => {
+    mock
+      .on('GET', REPO, { json: { default_branch: 'main' } })
+      .on('GET', '/git/ref/heads/main', { status: 500, json: {} })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.errorCode).toBe('E-1005')
+    expect(res.message).toBe('github.branchFetchFailed')
+  })
+
+  it('returns commitFetchFailed E-1007 when the commit fetch fails', async () => {
+    mock
+      .on('GET', REPO, { json: { default_branch: 'main' } })
+      .on('GET', '/git/ref/heads/main', { json: { object: { sha: 'h' } } })
+      .on('GET', '/git/commits/h', { status: 500, json: {} })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.errorCode).toBe('E-1007')
+    expect(res.message).toBe('github.commitFetchFailed')
+  })
+
+  it('returns treeCreateFailed E-1012 when POST /git/trees fails', async () => {
+    stageExistingRepo({ treeEntries: [] })
+    mock.on('POST', '/git/trees', { status: 500, json: {} })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.errorCode).toBe('E-1012')
+    expect(res.message).toBe('github.treeCreateFailed')
+  })
+
+  it('returns commitCreateFailed E-1014 when POST /git/commits fails', async () => {
+    stageExistingRepo({ treeEntries: [] })
+    mock
+      .on('POST', '/git/trees', { json: { sha: 'nt' } })
+      .on('POST', '/git/commits', { status: 422, json: {} })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.errorCode).toBe('E-1014')
+    expect(res.message).toBe('github.commitCreateFailed')
+  })
+
+  it('returns branchUpdateFailed E-1016 when PATCH ref fails (conflict / ref mismatch)', async () => {
+    stageExistingRepo({ treeEntries: [] })
+    mock
+      .on('POST', '/git/trees', { json: { sha: 'nt' } })
+      .on('POST', '/git/commits', { json: { sha: 'nc' } })
+      .on('PATCH', '/git/refs/heads/main', {
+        status: 422,
+        json: { message: 'Update is not a fast forward' },
+      })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.errorCode).toBe('E-1016')
+    expect(res.message).toBe('github.branchUpdateFailed')
+  })
+
+  it('returns networkError E-1017 when a fetch throws mid-sequence', async () => {
+    // repo ok, ref not queued -> throws -> caught
+    mock.on('GET', REPO, { json: { default_branch: 'main' } })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    expect(res.errorCode).toBe('E-1017')
+    expect(res.message).toBe('github.networkError')
+  })
+
+  it('throws-and-catches (E-1017) when the existing tree is truncated', async () => {
+    stageExistingRepo({ treeEntries: [], truncated: true })
+    const res = await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    // truncated は throw new Error → 関数の try/catch で E-1017 に化ける（現状挙動を pin）
+    expect(res.errorCode).toBe('E-1017')
+    expect(res.message).toBe('github.networkError')
+  })
+})
+
+// ============================================
+// options オーバーロード + アーカイブ
+// ============================================
+describe('pushAllWithTreeAPI: options overload + archive', () => {
+  it('accepts the PushOptions object form and writes archive metadata + leaves', async () => {
+    const archiveNotes = [makeNote({ id: 'anote-1', name: 'ArchNote' })]
+    const archiveLeaf = makeLeaf({
+      id: 'aleaf-1',
+      noteId: 'anote-1',
+      title: 'ArchLeaf',
+      content: 'archived body',
+    })
+    stageExistingRepo({ treeEntries: [] })
+    stageWriteSequence({})
+
+    const res = await pushAllWithTreeAPI({
+      leaves: [leaf],
+      notes,
+      settings: makeSettings(),
+      archiveLeaves: [archiveLeaf],
+      archiveNotes,
+      isArchiveLoaded: true,
+    })
+
+    expect(res.success).toBe(true)
+    expect(res.changedArchiveLeafCount).toBe(1)
+
+    const items: any[] = mock.firstCall('POST', '/git/trees')!.body.tree
+    const archLeafItem = items.find((i) => i.path === '.agasteer/archive/ArchNote/ArchLeaf.md')
+    expect(archLeafItem).toMatchObject({ content: 'archived body', mode: '100644', type: 'blob' })
+    const archMetaItem = items.find((i) => i.path === '.agasteer/archive/metadata.json')
+    expect(archMetaItem).toBeDefined()
+    const archMeta = JSON.parse(archMetaItem.content)
+    expect(archMeta.leaves['ArchNote/ArchLeaf.md']).toMatchObject({ id: 'aleaf-1' })
+  })
+
+  it('preserves existing archive files when the archive is not loaded', async () => {
+    stageExistingRepo({
+      treeEntries: [{ path: '.agasteer/archive/Old/keep.md', sha: 'old-archive-sha' }],
+    })
+    stageWriteSequence({})
+    const res = await pushAllWithTreeAPI({
+      leaves: [leaf],
+      notes,
+      settings: makeSettings(),
+      isArchiveLoaded: false,
+    })
+    expect(res.success).toBe(true)
+    const items: any[] = mock.firstCall('POST', '/git/trees')!.body.tree
+    const preserved = items.find((i) => i.path === '.agasteer/archive/Old/keep.md')
+    // 既存 sha のまま保持（content 再送なし）
+    expect(preserved).toMatchObject({ sha: 'old-archive-sha' })
+    expect('content' in preserved).toBe(false)
+  })
+
+  it('preserves non-.agasteer files (e.g. README) in the new tree', async () => {
+    stageExistingRepo({
+      treeEntries: [{ path: 'README.md', sha: 'readme-sha' }],
+    })
+    stageWriteSequence({})
+    await pushAllWithTreeAPI([leaf], notes, makeSettings())
+    const items: any[] = mock.firstCall('POST', '/git/trees')!.body.tree
+    const readme = items.find((i) => i.path === 'README.md')
+    expect(readme).toMatchObject({ path: 'README.md', sha: 'readme-sha' })
+  })
+})

--- a/src/lib/api/github/__tests__/github-status.characterization.test.ts
+++ b/src/lib/api/github/__tests__/github-status.characterization.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Characterization テスト（#231 Wave A）— 読み取り / 状態取得系
+ *
+ * 対象: fetchCurrentSha / fetchRemoteHeadSha / fetchRemotePushCount /
+ *       testGitHubConnection / saveToGitHub
+ *
+ * 本番コードは変更しない。現状の API 呼び出しシーケンス・戻り値・分岐を
+ * fetch モックで観測して golden master に固定する（挙動が quirky でも現状のまま pin）。
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+
+import {
+  createFetchMock,
+  makeSettings,
+  makeNote,
+  makeLeaf,
+  b64,
+  type FetchMock,
+} from './fetch-mock'
+
+// github.ts はバレル `../utils` 経由で `../stores` を読み、その先で localStorage に
+// 触れる（モジュール読み込み時）。既存の storage 系テストに倣い、localStorage を
+// スタブしてから動的 import する。
+const storageBacking = new Map<string, string>()
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => storageBacking.get(k) ?? null,
+  setItem: (k: string, v: string) => void storageBacking.set(k, v),
+  removeItem: (k: string) => void storageBacking.delete(k),
+  clear: () => storageBacking.clear(),
+  key: (i: number) => Array.from(storageBacking.keys())[i] ?? null,
+  get length() {
+    return storageBacking.size
+  },
+}
+
+const {
+  fetchCurrentSha,
+  fetchRemoteHeadSha,
+  fetchRemotePushCount,
+  testGitHubConnection,
+  saveToGitHub,
+  NOTES_METADATA_PATH,
+} = await import('../../github')
+
+let mock: FetchMock
+
+beforeEach(() => {
+  mock = createFetchMock()
+  vi.stubGlobal('fetch', mock.fn)
+  // console.error / warn を黙らせる（本番コードがエラー時に出力するため）
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+// ============================================
+// fetchCurrentSha
+// ============================================
+describe('fetchCurrentSha', () => {
+  it('GETs the Contents API with a Bearer token and returns the sha when present', async () => {
+    mock.on('GET', '/repos/owner/repo/contents/foo/bar.md', { json: { sha: 'abc123' } })
+
+    const sha = await fetchCurrentSha('foo/bar.md', makeSettings())
+
+    expect(sha).toBe('abc123')
+    const call = mock.firstCall('GET', '/contents/foo/bar.md')
+    expect(call).toBeDefined()
+    // キャッシュバスター ?t= が付く
+    expect(call!.url).toMatch(/\/repos\/owner\/repo\/contents\/foo\/bar\.md\?t=\d+/)
+    expect(call!.headers.Authorization).toBe('Bearer test-token')
+  })
+
+  it('returns null when the file does not exist (non-ok response)', async () => {
+    mock.on('GET', '/contents/missing.md', { status: 404, json: { message: 'Not Found' } })
+    expect(await fetchCurrentSha('missing.md', makeSettings())).toBeNull()
+  })
+
+  it('returns null and swallows network errors', async () => {
+    // キューに何も積まない → fetch は throw → catch で null
+    expect(await fetchCurrentSha('whatever.md', makeSettings())).toBeNull()
+  })
+})
+
+// ============================================
+// fetchRemoteHeadSha
+// ============================================
+describe('fetchRemoteHeadSha', () => {
+  it('returns settings_invalid before any fetch when token missing', async () => {
+    const res = await fetchRemoteHeadSha(makeSettings({ token: '' }))
+    expect(res).toEqual({ status: 'settings_invalid' })
+    expect(mock.calls).toHaveLength(0)
+  })
+
+  it('returns settings_invalid when repoName has no slash', async () => {
+    const res = await fetchRemoteHeadSha(makeSettings({ repoName: 'norepo' }))
+    expect(res).toEqual({ status: 'settings_invalid' })
+    expect(mock.calls).toHaveLength(0)
+  })
+
+  it('fetches repo then ref and returns the HEAD commit sha', async () => {
+    mock
+      .on('GET', '/repos/owner/repo', { json: { default_branch: 'develop' } })
+      .on('GET', '/git/ref/heads/develop', { json: { object: { sha: 'head-sha-1' } } })
+
+    const res = await fetchRemoteHeadSha(makeSettings())
+
+    expect(res).toEqual({ status: 'success', commitSha: 'head-sha-1' })
+    // repo 取得は cache: no-store
+    const repoCall = mock.firstCall('GET', 'https://api.github.com/repos/owner/repo')
+    expect(repoCall!.cache).toBe('no-store')
+    expect(repoCall!.headers.Authorization).toBe('Bearer test-token')
+    // ref はデフォルトブランチ名を使う
+    expect(mock.firstCall('GET', '/git/ref/heads/develop')).toBeDefined()
+  })
+
+  it('defaults branch to main when default_branch missing', async () => {
+    mock
+      .on('GET', '/repos/owner/repo', { json: {} })
+      .on('GET', '/git/ref/heads/main', { json: { object: { sha: 's' } } })
+    const res = await fetchRemoteHeadSha(makeSettings())
+    expect(res).toEqual({ status: 'success', commitSha: 's' })
+  })
+
+  it('maps repo 401/403 to auth_error', async () => {
+    mock.on('GET', '/repos/owner/repo', { status: 403, json: {} })
+    expect(await fetchRemoteHeadSha(makeSettings())).toEqual({ status: 'auth_error' })
+  })
+
+  it('maps other repo failures to network_error', async () => {
+    mock.on('GET', '/repos/owner/repo', { status: 500, json: {} })
+    expect(await fetchRemoteHeadSha(makeSettings())).toEqual({ status: 'network_error' })
+  })
+
+  it('maps ref 404/409 to empty_repository', async () => {
+    mock
+      .on('GET', '/repos/owner/repo', { json: { default_branch: 'main' } })
+      .on('GET', '/git/ref/heads/main', { status: 409, json: {} })
+    expect(await fetchRemoteHeadSha(makeSettings())).toEqual({ status: 'empty_repository' })
+  })
+
+  it('maps ref 401/403 to auth_error', async () => {
+    mock
+      .on('GET', '/repos/owner/repo', { json: { default_branch: 'main' } })
+      .on('GET', '/git/ref/heads/main', { status: 401, json: {} })
+    expect(await fetchRemoteHeadSha(makeSettings())).toEqual({ status: 'auth_error' })
+  })
+
+  it('returns network_error (with error) when fetch throws', async () => {
+    // 何も積まない → repo fetch が throw
+    const res = await fetchRemoteHeadSha(makeSettings())
+    expect(res.status).toBe('network_error')
+  })
+})
+
+// ============================================
+// fetchRemotePushCount
+// ============================================
+describe('fetchRemotePushCount', () => {
+  it('returns settings_invalid before fetch when settings invalid', async () => {
+    expect(await fetchRemotePushCount(makeSettings({ token: '' }))).toEqual({
+      status: 'settings_invalid',
+    })
+    expect(mock.calls).toHaveLength(0)
+  })
+
+  it('reads metadata.json via Contents API and returns pushCount', async () => {
+    const meta = JSON.stringify({ version: 1, notes: {}, leaves: {}, pushCount: 7 })
+    mock.on('GET', `/contents/${NOTES_METADATA_PATH}`, { json: { content: b64(meta) } })
+
+    const res = await fetchRemotePushCount(makeSettings())
+    expect(res).toEqual({ status: 'success', pushCount: 7 })
+
+    const call = mock.firstCall('GET', `/contents/${NOTES_METADATA_PATH}`)
+    expect(call!.headers.Authorization).toBe('Bearer test-token')
+  })
+
+  it('defaults pushCount to 0 when field absent', async () => {
+    const meta = JSON.stringify({ version: 1, notes: {}, leaves: {} })
+    mock.on('GET', `/contents/${NOTES_METADATA_PATH}`, { json: { content: b64(meta) } })
+    expect(await fetchRemotePushCount(makeSettings())).toEqual({ status: 'success', pushCount: 0 })
+  })
+
+  it('maps 404/409 to empty_repository', async () => {
+    mock.on('GET', `/contents/${NOTES_METADATA_PATH}`, { status: 404, json: {} })
+    expect(await fetchRemotePushCount(makeSettings())).toEqual({ status: 'empty_repository' })
+  })
+
+  it('maps 401/403 to auth_error', async () => {
+    mock.on('GET', `/contents/${NOTES_METADATA_PATH}`, { status: 403, json: {} })
+    expect(await fetchRemotePushCount(makeSettings())).toEqual({ status: 'auth_error' })
+  })
+
+  it('maps other errors to network_error', async () => {
+    mock.on('GET', `/contents/${NOTES_METADATA_PATH}`, { status: 500, json: {} })
+    expect(await fetchRemotePushCount(makeSettings())).toEqual({ status: 'network_error' })
+  })
+
+  it('returns network_error when ok response has no content field', async () => {
+    // ok かつ content 無し → if 群を全部すり抜けて最後の network_error に落ちる
+    mock.on('GET', `/contents/${NOTES_METADATA_PATH}`, { status: 200, json: {} })
+    expect(await fetchRemotePushCount(makeSettings())).toEqual({ status: 'network_error' })
+  })
+
+  it('returns network_error (with error) when fetch throws', async () => {
+    const res = await fetchRemotePushCount(makeSettings())
+    expect(res.status).toBe('network_error')
+  })
+})
+
+// ============================================
+// testGitHubConnection
+// ============================================
+describe('testGitHubConnection', () => {
+  it('returns settings_invalid errorCode E-3001 before any fetch', async () => {
+    const res = await testGitHubConnection(makeSettings({ token: '' }))
+    expect(res.success).toBe(false)
+    expect(res.errorCode).toBe('E-3001')
+    expect(mock.calls).toHaveLength(0)
+  })
+
+  it('checks /user then /repos and returns connectionOk', async () => {
+    mock
+      .on('GET', 'https://api.github.com/user', { json: { login: 'me' } })
+      .on('GET', 'https://api.github.com/repos/owner/repo', { json: { id: 1 } })
+
+    const res = await testGitHubConnection(makeSettings())
+    expect(res).toEqual({ success: true, message: 'github.connectionOk' })
+
+    const userCall = mock.firstCall('GET', 'https://api.github.com/user')
+    expect(userCall!.cache).toBe('no-store')
+    expect(userCall!.headers.Authorization).toBe('Bearer test-token')
+  })
+
+  it('maps user 401 to invalidToken E-3002', async () => {
+    mock.on('GET', 'https://api.github.com/user', { status: 401, json: {} })
+    const res = await testGitHubConnection(makeSettings())
+    expect(res.message).toBe('github.invalidToken')
+    expect(res.errorCode).toBe('E-3002')
+    expect(res.httpStatus).toBe(401)
+  })
+
+  it('maps user rate-limit (403 remaining 0) to rateLimited E-3003', async () => {
+    mock.on('GET', 'https://api.github.com/user', {
+      status: 403,
+      json: {},
+      headers: { 'X-RateLimit-Remaining': '0' },
+    })
+    const res = await testGitHubConnection(makeSettings())
+    expect(res.message).toBe('github.rateLimited')
+    expect(res.errorCode).toBe('E-3003')
+    expect(res.rateLimitInfo?.isRateLimited).toBe(true)
+  })
+
+  it('maps generic user failure to userFetchFailed E-3004', async () => {
+    mock.on('GET', 'https://api.github.com/user', { status: 500, json: {} })
+    const res = await testGitHubConnection(makeSettings())
+    expect(res.message).toBe('github.userFetchFailed')
+    expect(res.errorCode).toBe('E-3004')
+  })
+
+  it('maps repo 404 to repoNotFound E-3005', async () => {
+    mock
+      .on('GET', 'https://api.github.com/user', { json: { login: 'me' } })
+      .on('GET', 'https://api.github.com/repos/owner/repo', { status: 404, json: {} })
+    const res = await testGitHubConnection(makeSettings())
+    expect(res.message).toBe('github.repoNotFound')
+    expect(res.errorCode).toBe('E-3005')
+  })
+
+  it('maps repo 401 to noPermission E-3007', async () => {
+    mock
+      .on('GET', 'https://api.github.com/user', { json: { login: 'me' } })
+      .on('GET', 'https://api.github.com/repos/owner/repo', { status: 401, json: {} })
+    const res = await testGitHubConnection(makeSettings())
+    expect(res.message).toBe('github.noPermission')
+    expect(res.errorCode).toBe('E-3007')
+  })
+
+  it('maps thrown error to networkError E-3009', async () => {
+    const res = await testGitHubConnection(makeSettings())
+    expect(res.message).toBe('github.networkError')
+    expect(res.errorCode).toBe('E-3009')
+  })
+})
+
+// ============================================
+// saveToGitHub（単一ファイル保存）
+// ============================================
+describe('saveToGitHub', () => {
+  const notes = [makeNote({ id: 'note-1', name: 'MyNote' })]
+  const leaf = makeLeaf({ noteId: 'note-1', title: 'MyLeaf', content: 'body text' })
+
+  it('returns validation error key without fetching when settings invalid', async () => {
+    const res = await saveToGitHub(leaf, notes, makeSettings({ token: '' }))
+    expect(res).toEqual({ success: false, message: 'github.tokenNotSet' })
+    expect(mock.calls).toHaveLength(0)
+  })
+
+  it('fetches current sha then PUTs content with sha for existing files', async () => {
+    // 1) fetchCurrentSha -> Contents GET returns sha
+    mock.on('GET', '/contents/.agasteer/notes/MyNote/MyLeaf.md', {
+      json: { sha: 'existing-sha' },
+    })
+    // 2) PUT Contents API
+    mock.on('PUT', '/contents/.agasteer/notes/MyNote/MyLeaf.md', { json: { content: {} } })
+
+    const res = await saveToGitHub(leaf, notes, makeSettings())
+    expect(res).toEqual({ success: true, message: 'github.pushOk' })
+
+    const put = mock.firstCall('PUT', '/contents/.agasteer/notes/MyNote/MyLeaf.md')
+    expect(put).toBeDefined()
+    expect(put!.headers.Authorization).toBe('Bearer test-token')
+    expect(put!.headers['Content-Type']).toBe('application/json')
+    expect(put!.body.message).toBe('Agasteer push')
+    // 既存ファイルなので sha が含まれる
+    expect(put!.body.sha).toBe('existing-sha')
+    // content は base64
+    expect(put!.body.content).toBe(b64('body text'))
+    expect(put!.body.committer).toEqual({
+      name: 'agasteer',
+      email: 'agasteer@users.noreply.github.com',
+    })
+  })
+
+  it('omits sha when the file does not exist yet (new file)', async () => {
+    mock.on('GET', '/contents/.agasteer/notes/MyNote/MyLeaf.md', { status: 404, json: {} })
+    mock.on('PUT', '/contents/.agasteer/notes/MyNote/MyLeaf.md', { json: {} })
+
+    const res = await saveToGitHub(leaf, notes, makeSettings())
+    expect(res.success).toBe(true)
+    const put = mock.firstCall('PUT', '/contents/.agasteer/notes/MyNote/MyLeaf.md')
+    expect('sha' in put!.body).toBe(false)
+  })
+
+  it('returns networkError when PUT is not ok', async () => {
+    mock.on('GET', '/contents/.agasteer/notes/MyNote/MyLeaf.md', { status: 404, json: {} })
+    mock.on('PUT', '/contents/.agasteer/notes/MyNote/MyLeaf.md', { status: 422, json: {} })
+    const res = await saveToGitHub(leaf, notes, makeSettings())
+    expect(res).toEqual({ success: false, message: 'github.networkError' })
+  })
+
+  it('returns networkError when PUT throws', async () => {
+    // GET succeeds, PUT not queued -> throws -> catch
+    mock.on('GET', '/contents/.agasteer/notes/MyNote/MyLeaf.md', { status: 404, json: {} })
+    const res = await saveToGitHub(leaf, notes, makeSettings())
+    expect(res).toEqual({ success: false, message: 'github.networkError' })
+  })
+})


### PR DESCRIPTION
Refs #231

## 概要
同期層（GitHub を直接バックエンドにする push/status 系）の characterization テストを追加。**本番コードは1行も変更していない**（`src/lib/api/github/__tests__/` の新規追加のみ）。現状の振る舞いを fetch モックで観測し golden master に固定する安全網で、#226 の push/pull 分割前のデグレ検知が目的。

## スコープ
- Wave A = push / status / 共通基盤
- pull（`pullFromGitHub` / `pullArchive`）は **Wave B** なので本 PR では触れていない

## 追加物
- `__tests__/fetch-mock.ts` — URL+method でレスポンスをキュー・段階応答する再利用可能な fetch モック基盤＋ダミーデータヘルパ（Wave B からも再利用可）
- `__tests__/github-status.characterization.test.ts`（33件）— `fetchCurrentSha` / `fetchRemoteHeadSha` / `fetchRemotePushCount` / `testGitHubConnection` / `saveToGitHub`
- `__tests__/github-push.characterization.test.ts`（24件）— `pushAllWithTreeAPI` の API 呼び出し列・リクエストボディ・差分判定（変更なし early return）・空リポ初期化・rate-limit/各エラー分岐・アーカイブ・options オーバーロード

## 検証
- `npm test`: 216 passed（既存 159 不変 + 新規 57）
- `npm run lint`: prettier + svelte-check 0 エラー
- 本番コード不変: `git diff main...HEAD -- 'src/lib/**/*.ts' ':!**/__tests__/**'` が空

## 観測した現状挙動（pin 済・修正はしない）
- Authorization は `Bearer <token>`（PAT の `token <...>` 形式ではない）
- 既存 tree が `truncated` のときは `throw` するが、関数の try/catch に拾われ最終的に `E-1017`/networkError に化ける
- `fetchRemotePushCount` は ok 応答でも `content` 欠落だと全 if をすり抜けて `network_error` に落ちる

## follow-up / Wave B 候補
- `runWithConcurrency`・`fetchGitHubContents` は未 export のため直接テスト不可。pull 経路（Wave B）で `pullFromGitHub` 越しに並行数・順序を pin する
- `pullFromGitHub` / `pullArchive` の characterization（段階ロードコールバック・優先度ソート・blob SHA キャッシュ・部分失敗）