### PR TITLE
test: env-gated e2e scaffold for real GitHub sync + runbook

### DIFF
--- a/docs/development/e2e-setup.md
+++ b/docs/development/e2e-setup.md
@@ -1,0 +1,106 @@
+# 実 GitHub 往復 e2e テストのセットアップ・ランブック
+
+`tests/e2e/github-sync.e2e.test.ts` は、`pushAllWithTreeAPI` / `pullFromGitHub`
+（`src/lib/api/github.ts`）を**実際の GitHub API** に対して呼び、notes ツリー
+（`.agasteer/notes/`）の push→pull 往復健全性・冪等性・増分反映を検証する e2e テストです。
+fetch はモックしません。
+
+通常の `npm test` / CI では env ゲートで**丸ごと skip**されます（緑のまま）。
+下記の env を揃えたときだけ走ります。
+
+> **このスキャフォールドは実 GitHub に対して pass することを未検証です。**
+> 書いた時点ではテスト用リポ/トークンが未用意のため、env 無しでの skip・型・公開 API
+> 整合までは保証済みですが、実 GitHub に対して実際に green になるかは未確認です。
+> 下記手順で fixture を用意して走らせ、落ちたら追って直す前提です。
+
+---
+
+## kako-jun がやる手作業は 2 つだけ
+
+1. **使い捨てテスト用リポジトリを作る**
+2. **そのリポだけに書ける fine-grained PAT を発行する**
+
+あとは env を渡して `npm run test:e2e` を叩けば即走ります。
+
+---
+
+## 1. 使い捨てテスト用リポジトリを作る
+
+- 例: `kako-jun/agasteer-e2e-fixture`（**private 可**）
+- **本物の notes リポは絶対に使わない。**
+  このアプリの push は `.agasteer/notes/` ツリー全体を**上書き再構築**します。
+  本物のリポを誤って指すと中身を破壊します。
+- **中身が消えてよいリポであること。** テストは毎 run このリポを書き換え、
+  最後に既知のベース状態へ reset push します。
+- 空リポでも構いません（テストが初回 push で初期化します）。
+
+```sh
+gh repo create kako-jun/agasteer-e2e-fixture --private --description "Agasteer e2e fixture (disposable, contents will be overwritten)"
+```
+
+## 2. fine-grained PAT を発行する
+
+GitHub → Settings → Developer settings → Fine-grained tokens → Generate new token
+
+- **Repository access**: Only select repositories → `agasteer-e2e-fixture` **だけ**
+- **Permissions** → Repository permissions → **Contents: Read and write**
+  （他のリポ・他の権限は一切付けない）
+- Expiration は短め（テスト時のみ使うなら 7〜30 日で十分）
+
+発行されたトークン文字列を控えます（**commit しない**）。
+
+---
+
+## 3. env 一覧
+
+| env                         | 必須 | 説明                                                                         |
+| --------------------------- | ---- | ---------------------------------------------------------------------------- |
+| `AGASTEER_E2E_GITHUB_TOKEN` | ○    | 上で発行した fine-grained PAT                                                |
+| `AGASTEER_E2E_OWNER`        | ○    | テスト用リポの owner（例: `kako-jun`）                                       |
+| `AGASTEER_E2E_REPO`         | ○    | テスト用リポ名（例: `agasteer-e2e-fixture`）                                 |
+| `AGASTEER_E2E_BRANCH`       | -    | ブランチ（既定 `main`。sync 層は default branch を自動検出するので通常不要） |
+| `AGASTEER_E2E_ALLOW_WRITES` | ○    | **`1` のときだけ書き込みを許可**（誤爆防止の必須フラグ）                     |
+
+`AGASTEER_E2E_ALLOW_WRITES=1` が無いと、トークン等が揃っていても describe ごと skip され、
+**一切書き込みません**。本物リポへの誤爆を防ぐ二重ガードです。
+
+---
+
+## 4. 実行方法
+
+env をその場で渡して `test:e2e` を叩きます（`-t e2e` で e2e 名のテストだけ走ります）:
+
+```sh
+AGASTEER_E2E_GITHUB_TOKEN='github_pat_...' \
+AGASTEER_E2E_OWNER='kako-jun' \
+AGASTEER_E2E_REPO='agasteer-e2e-fixture' \
+AGASTEER_E2E_ALLOW_WRITES=1 \
+npm run test:e2e
+```
+
+env を渡さずに `npm test` / `npm run test:e2e` を叩いた場合、往復テストは skip され、
+「e2e suite is skipped when env is absent」という sanity テストだけが green になります。
+
+---
+
+## 5. テスト内容
+
+直列（宣言順）に実行されます:
+
+1. **往復一致** — 複数ノート・サブフォルダ・日本語/絵文字を含むリーフ・metadata を構築 →
+   push → pull → 相対パス→本文の Map・ノート構造・metadata エントリが push 内容と一致。
+2. **冪等 push** — 同一状態をもう一度 push → `github.noChanges` 経路。
+3. **増分** — 1 リーフだけ本文変更 → 再 push（`changedLeafCount === 1`）→ pull で反映確認。
+
+`afterAll` で既知のベース状態へ reset push し、次回 run をクリーンに保ちます。
+
+---
+
+## 6. 安全注意
+
+- **本物の notes リポを `AGASTEER_E2E_REPO` に指さない。** 使い捨て fixture リポ専用。
+- **トークンを commit しない。** `.env` / `.env.local` は `.gitignore` 済み
+  （リポ直下 `.gitignore` の "Environment variables" セクションを参照）。
+  シェルにその場で渡すのが最も安全。
+- PAT は対象リポの Contents read/write **だけ**。他リポ・他権限を与えない。
+- テストは push で全 notes ツリーを上書きする。fixture リポの中身は消えてよい前提。

--- a/docs/development/e2e-setup.md
+++ b/docs/development/e2e-setup.md
@@ -53,13 +53,14 @@ GitHub → Settings → Developer settings → Fine-grained tokens → Generate 
 
 ## 3. env 一覧
 
-| env                         | 必須 | 説明                                                                         |
-| --------------------------- | ---- | ---------------------------------------------------------------------------- |
-| `AGASTEER_E2E_GITHUB_TOKEN` | ○    | 上で発行した fine-grained PAT                                                |
-| `AGASTEER_E2E_OWNER`        | ○    | テスト用リポの owner（例: `kako-jun`）                                       |
-| `AGASTEER_E2E_REPO`         | ○    | テスト用リポ名（例: `agasteer-e2e-fixture`）                                 |
-| `AGASTEER_E2E_BRANCH`       | -    | ブランチ（既定 `main`。sync 層は default branch を自動検出するので通常不要） |
-| `AGASTEER_E2E_ALLOW_WRITES` | ○    | **`1` のときだけ書き込みを許可**（誤爆防止の必須フラグ）                     |
+| env                         | 必須 | 説明                                                     |
+| --------------------------- | ---- | -------------------------------------------------------- |
+| `AGASTEER_E2E_GITHUB_TOKEN` | ○    | 上で発行した fine-grained PAT                            |
+| `AGASTEER_E2E_OWNER`        | ○    | テスト用リポの owner（例: `kako-jun`）                   |
+| `AGASTEER_E2E_REPO`         | ○    | テスト用リポ名（例: `agasteer-e2e-fixture`）             |
+| `AGASTEER_E2E_ALLOW_WRITES` | ○    | **`1` のときだけ書き込みを許可**（誤爆防止の必須フラグ） |
+
+> ブランチは指定不要。sync 層（push/pull）はリポの default branch を自動検出する。
 
 `AGASTEER_E2E_ALLOW_WRITES=1` が無いと、トークン等が揃っていても describe ごと skip され、
 **一切書き込みません**。本物リポへの誤爆を防ぐ二重ガードです。

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "prepare": "husky",
     "test": "vitest run",
+    "test:e2e": "vitest run -t e2e",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/tests/e2e/github-sync.e2e.test.ts
+++ b/tests/e2e/github-sync.e2e.test.ts
@@ -14,8 +14,9 @@
  *   AGASTEER_E2E_GITHUB_TOKEN  fine-grained PAT（テスト用リポだけに Contents read/write）
  *   AGASTEER_E2E_OWNER         テスト用リポの owner（例: kako-jun）
  *   AGASTEER_E2E_REPO          テスト用リポ名（例: agasteer-e2e-fixture）
- *   AGASTEER_E2E_BRANCH        ブランチ（既定 main）
  *   AGASTEER_E2E_ALLOW_WRITES  "1" のときだけ書き込みを許可（誤爆防止の必須フラグ）
+ *
+ * 注: ブランチは指定しない。sync 層（push/pull）はリポの default branch を自動検出する。
  *
  * ## 危険性（ランブック docs/development/e2e-setup.md 参照）
  * このアプリの push は notes ツリー全体を**上書き再構築**する。本物の notes リポを
@@ -61,7 +62,6 @@ const env = (k: string): string | undefined => {
 const E2E_TOKEN = env('AGASTEER_E2E_GITHUB_TOKEN')
 const E2E_OWNER = env('AGASTEER_E2E_OWNER')
 const E2E_REPO = env('AGASTEER_E2E_REPO')
-const E2E_BRANCH = env('AGASTEER_E2E_BRANCH') ?? 'main'
 const E2E_ALLOW_WRITES = env('AGASTEER_E2E_ALLOW_WRITES') === '1'
 
 /**

--- a/tests/e2e/github-sync.e2e.test.ts
+++ b/tests/e2e/github-sync.e2e.test.ts
@@ -1,0 +1,287 @@
+/**
+ * 実 GitHub 往復 e2e テスト（#231）
+ *
+ * pushAllWithTreeAPI / pullFromGitHub を **実際の GitHub API** に対して呼び、
+ * notes ツリー（.agasteer/notes/）の push→pull 往復健全性・冪等性・増分反映を検証する。
+ * fetch はモックしない。
+ *
+ * ## 通常は丸ごと skip される
+ * 後述の env が全て揃い、かつ AGASTEER_E2E_ALLOW_WRITES=1 が明示されたときだけ走る。
+ * env が無ければ `describe.skipIf` で describe ごと skip され、通常の `npm test` は
+ * 影響を受けない（緑のまま、本テストは skipped 表示）。
+ *
+ * ## 必要な env
+ *   AGASTEER_E2E_GITHUB_TOKEN  fine-grained PAT（テスト用リポだけに Contents read/write）
+ *   AGASTEER_E2E_OWNER         テスト用リポの owner（例: kako-jun）
+ *   AGASTEER_E2E_REPO          テスト用リポ名（例: agasteer-e2e-fixture）
+ *   AGASTEER_E2E_BRANCH        ブランチ（既定 main）
+ *   AGASTEER_E2E_ALLOW_WRITES  "1" のときだけ書き込みを許可（誤爆防止の必須フラグ）
+ *
+ * ## 危険性（ランブック docs/development/e2e-setup.md 参照）
+ * このアプリの push は notes ツリー全体を**上書き再構築**する。本物の notes リポを
+ * 誤って指すと中身を破壊する。だから「中身が消えてよい使い捨てリポ」+ ALLOW_WRITES
+ * フラグの二重ガードを掛けている。
+ *
+ * ## 実 GitHub に対しての pass は未検証（重要）
+ * このスキャフォールドを書いた時点では kako-jun のテスト用リポ/トークンが未用意のため、
+ * 実 GitHub に対して実際に green になることは**未検証**。env を用意して走らせ、
+ * 落ちたら追って直す前提。型・公開 API 整合・env 無しでの skip までは保証済み。
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+
+import type { Leaf, Note, Metadata, Settings } from '../../src/lib/types'
+
+// github.ts は ../utils バレル経由で stores を巻き込み、モジュール読み込み時に
+// localStorage に触れる（characterization テストと同じ理由）。静的 import だと
+// 評価順で落ちるため、localStorage をスタブしてから動的 import する。
+const storageBacking = new Map<string, string>()
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => storageBacking.get(k) ?? null,
+  setItem: (k: string, v: string) => void storageBacking.set(k, v),
+  removeItem: (k: string) => void storageBacking.delete(k),
+  clear: () => storageBacking.clear(),
+  key: (i: number) => Array.from(storageBacking.keys())[i] ?? null,
+  get length() {
+    return storageBacking.size
+  },
+}
+
+const { pushAllWithTreeAPI, pullFromGitHub } = await import('../../src/lib/api/github')
+
+// ============================================
+// env ゲート
+// ============================================
+
+const env = (k: string): string | undefined => {
+  const v = process.env[k]
+  return v && v.length > 0 ? v : undefined
+}
+
+const E2E_TOKEN = env('AGASTEER_E2E_GITHUB_TOKEN')
+const E2E_OWNER = env('AGASTEER_E2E_OWNER')
+const E2E_REPO = env('AGASTEER_E2E_REPO')
+const E2E_BRANCH = env('AGASTEER_E2E_BRANCH') ?? 'main'
+const E2E_ALLOW_WRITES = env('AGASTEER_E2E_ALLOW_WRITES') === '1'
+
+/**
+ * 全ガードが揃って初めて true。
+ * - token / owner / repo が揃う
+ * - ALLOW_WRITES=1 が明示されている（誤爆防止）
+ */
+const hasE2eEnv = Boolean(E2E_TOKEN && E2E_OWNER && E2E_REPO && E2E_ALLOW_WRITES)
+
+// ============================================
+// テスト用データ構築ヘルパ
+// ============================================
+
+const REPO_NAME = `${E2E_OWNER}/${E2E_REPO}`
+
+function makeSettings(): Settings {
+  return {
+    token: E2E_TOKEN ?? '',
+    repoName: REPO_NAME,
+    theme: 'yomi',
+    toolName: 'Agasteer',
+    locale: 'ja',
+  }
+}
+
+let noteSeq = 0
+let leafSeq = 0
+
+function makeNote(name: string, opts: Partial<Note> = {}): Note {
+  noteSeq += 1
+  return {
+    id: opts.id ?? `e2e-note-${noteSeq}`,
+    name,
+    parentId: opts.parentId,
+    order: opts.order ?? noteSeq,
+    badgeIcon: opts.badgeIcon,
+    badgeColor: opts.badgeColor,
+  }
+}
+
+function makeLeaf(title: string, noteId: string, content: string, opts: Partial<Leaf> = {}): Leaf {
+  leafSeq += 1
+  return {
+    id: opts.id ?? `e2e-leaf-${leafSeq}`,
+    title,
+    noteId,
+    content,
+    updatedAt: opts.updatedAt ?? 1_700_000_000_000 + leafSeq,
+    order: opts.order ?? leafSeq,
+    badgeIcon: opts.badgeIcon,
+    badgeColor: opts.badgeColor,
+  }
+}
+
+/**
+ * push した内容と pull した内容を**パス・本文ベース**で比較するための正規化。
+ *
+ * push は leaf.title をファイル名に、note 階層をディレクトリにして
+ * `<note>/.../<title>.md` という相対パスを作る。pull はそのパスから title を、
+ * metadata から id/order/noteId/updatedAt を復元する。
+ * よって「相対パス → 本文」の Map と「ノート名 → 親ノート名」の集合が一致すれば往復健全。
+ */
+function leafPathContentMap(leaves: Leaf[], notes: Note[]): Map<string, string> {
+  const noteById = new Map(notes.map((n) => [n.id, n]))
+  const folderPath = (note: Note): string => {
+    const parent = note.parentId ? noteById.get(note.parentId) : undefined
+    return parent ? `${parent.name}/${note.name}` : note.name
+  }
+  const sanitize = (raw: string): string => {
+    const cleaned = raw.replace(/[\\/:*?"<>|#]/g, '-').replace(/\s+/g, ' ')
+    const limited = cleaned.slice(0, 80)
+    return limited.length === 0 ? 'Untitled' : limited
+  }
+  const map = new Map<string, string>()
+  for (const leaf of leaves) {
+    const note = noteById.get(leaf.noteId)
+    const dir = note ? folderPath(note) : ''
+    const rel = dir ? `${dir}/${sanitize(leaf.title)}.md` : `${sanitize(leaf.title)}.md`
+    map.set(rel, leaf.content)
+  }
+  return map
+}
+
+/** ノート集合を「フルパス」で表現（親名/子名）。pull 後の構造比較に使う。 */
+function noteFullPaths(notes: Note[]): Set<string> {
+  const byId = new Map(notes.map((n) => [n.id, n]))
+  const full = (note: Note): string => {
+    const parent = note.parentId ? byId.get(note.parentId) : undefined
+    return parent ? `${parent.name}/${note.name}` : note.name
+  }
+  return new Set(notes.map(full))
+}
+
+// 全 run 通しで使う既知 fixture 状態（複数ノート・サブフォルダ・日本語/絵文字・metadata）
+function buildBaseState(): { leaves: Leaf[]; notes: Note[]; metadata: Metadata } {
+  noteSeq = 0
+  leafSeq = 0
+
+  const rootA = makeNote('日記', { order: 0, badgeIcon: 'pencil', badgeColor: '#46B278' })
+  const rootB = makeNote('Tech', { order: 1 })
+  const subB = makeNote('rust 🦀', { parentId: rootB.id, order: 0 })
+
+  const notes: Note[] = [rootA, rootB, subB]
+
+  const leaves: Leaf[] = [
+    makeLeaf('今日の出来事', rootA.id, '# 今日\n\nお茶を飲んだ。🍵\n', {
+      order: 0,
+      badgeIcon: 'star',
+    }),
+    makeLeaf('memo', rootB.id, 'plain ascii note\n', { order: 0 }),
+    makeLeaf('所有権 🦀', subB.id, '# Ownership\n\nborrow checker と仲良く。\n絵文字 ✅\n', {
+      order: 0,
+    }),
+  ]
+
+  const metadata: Metadata = { version: 1, notes: {}, leaves: {}, pushCount: 0 }
+  return { leaves, notes, metadata }
+}
+
+// ============================================
+// テスト本体（env 無しでは describe ごと skip）
+// ============================================
+
+describe.skipIf(!hasE2eEnv)('e2e: real GitHub sync round-trip', () => {
+  const settings = makeSettings()
+
+  beforeAll(() => {
+    // 念押しのガード。万一 skipIf を抜けても ALLOW_WRITES 無しでは絶対に書かない。
+    if (!E2E_ALLOW_WRITES) {
+      throw new Error(
+        'AGASTEER_E2E_ALLOW_WRITES=1 is required to run write-heavy e2e tests. Refusing to write.'
+      )
+    }
+  })
+
+  afterAll(async () => {
+    // 後始末: 既知のベース状態へ reset push して、次回 run をクリーンに保つ。
+    if (!hasE2eEnv) return
+    const { leaves, notes, metadata } = buildBaseState()
+    await pushAllWithTreeAPI({ leaves, notes, settings, localMetadata: metadata })
+  })
+
+  // 順序依存（直列）。push した状態を後続テストが前提にするため it.sequential 相当に
+  // 並べる。vitest はファイル内テストを宣言順に直列実行する（並列化は別ファイル間のみ）。
+
+  it('e2e push then pull yields identical paths, content, and note structure', async () => {
+    const { leaves, notes, metadata } = buildBaseState()
+
+    const pushed = await pushAllWithTreeAPI({ leaves, notes, settings, localMetadata: metadata })
+    expect(pushed.success, `push failed: ${pushed.message} ${pushed.errorCode ?? ''}`).toBe(true)
+
+    // 別の空状態へ pull
+    const pull = await pullFromGitHub(settings)
+    expect(pull.success, `pull failed: ${pull.message} ${pull.errorCode ?? ''}`).toBe(true)
+
+    // 往復一致: パス→本文の Map が一致
+    const expectedMap = leafPathContentMap(leaves, notes)
+    const actualMap = leafPathContentMap(pull.leaves, pull.notes)
+    expect(actualMap.size).toBe(expectedMap.size)
+    for (const [path, content] of expectedMap) {
+      expect(actualMap.has(path), `missing leaf path after pull: ${path}`).toBe(true)
+      expect(actualMap.get(path)).toBe(content)
+    }
+
+    // ノート構造（サブフォルダ含む）一致
+    const expectedNotes = noteFullPaths(notes)
+    const actualNotes = noteFullPaths(pull.notes)
+    expect(actualNotes).toEqual(expectedNotes)
+
+    // metadata 健全性: pull した metadata.leaves に各リーフ相対パスのエントリがある
+    for (const path of expectedMap.keys()) {
+      expect(pull.metadata.leaves[path], `metadata.leaves missing entry for ${path}`).toBeDefined()
+    }
+  })
+
+  it('e2e idempotent push reports noChanges on identical state', async () => {
+    const { leaves, notes, metadata } = buildBaseState()
+
+    // 1 回目（前テストの状態と同一なので noChanges になる想定だが、念のため push）
+    await pushAllWithTreeAPI({ leaves, notes, settings, localMetadata: metadata })
+
+    // 2 回目: 同一状態 → 変更なし経路
+    const again = await pushAllWithTreeAPI({ leaves, notes, settings, localMetadata: metadata })
+    expect(again.success).toBe(true)
+    expect(again.message).toBe('github.noChanges')
+    expect(again.changedLeafCount ?? 0).toBe(0)
+  })
+
+  it('e2e incremental: editing one leaf is reflected on next pull', async () => {
+    const { leaves, notes, metadata } = buildBaseState()
+    await pushAllWithTreeAPI({ leaves, notes, settings, localMetadata: metadata })
+
+    // 1 リーフだけ本文を変更
+    const edited = leaves.map((l) =>
+      l.title === 'memo' ? { ...l, content: 'plain ascii note\n\nEDITED ✏️\n' } : l
+    )
+
+    const pushed = await pushAllWithTreeAPI({
+      leaves: edited,
+      notes,
+      settings,
+      localMetadata: metadata,
+    })
+    expect(pushed.success).toBe(true)
+    // 変更ありなので noChanges ではないこと、変更リーフ数 1 を期待
+    expect(pushed.message).not.toBe('github.noChanges')
+    expect(pushed.changedLeafCount).toBe(1)
+
+    const pull = await pullFromGitHub(settings)
+    expect(pull.success).toBe(true)
+    const actualMap = leafPathContentMap(pull.leaves, pull.notes)
+    // memo は Tech ノート直下なので相対パスは `Tech/memo.md`
+    expect(actualMap.get('Tech/memo.md')).toBe('plain ascii note\n\nEDITED ✏️\n')
+  })
+})
+
+// env 無しのときに「ちゃんと skip された」ことを可視化する軽量テスト（常に走る）。
+// hasE2eEnv が false なら 1 件 green、true なら skip（本体側で実検証するため）。
+describe('e2e gate sanity (always runs)', () => {
+  it.skipIf(hasE2eEnv)('e2e suite is skipped when env is absent', () => {
+    expect(hasE2eEnv).toBe(false)
+  })
+})


### PR DESCRIPTION
Refs #231

実 GitHub に対する push/pull 往復の e2e テストを **env ゲート付き（普段は skip）** で追加する。kako-jun はテスト用リポ/PAT を用意するだけで即走る状態。

## 内容
- **`tests/e2e/github-sync.e2e.test.ts`**: `describe.skipIf(!hasE2eEnv)` で env が揃わなければ丸ごと skip。実 `pushAllWithTreeAPI` / `pullFromGitHub` を実 GitHub に対して呼ぶ（モックしない）。
  - 往復一致（複数ノート・サブフォルダ・日本語/絵文字リーフ・metadata を push→pull で照合）
  - 冪等 push（同一状態の再 push が `github.noChanges`）
  - 増分（1 リーフ変更 → `changedLeafCount===1` → pull で反映）
  - `afterAll` で既知ベース状態へ reset push（後始末）
- 必要 env: `AGASTEER_E2E_GITHUB_TOKEN` / `AGASTEER_E2E_OWNER` / `AGASTEER_E2E_REPO` / `AGASTEER_E2E_BRANCH`(既定 main)、**さらに誤爆防止に `AGASTEER_E2E_ALLOW_WRITES=1` を必須**（全 notes ツリーを上書きするため二重ガード）。
- **`package.json`**: `test:e2e` script（`vitest run -t e2e`）を追加。既存 script は据え置き。
- **`docs/development/e2e-setup.md`**: 使い捨て fixture リポ作成 + そのリポだけに Contents read/write を持つ fine-grained PAT 発行、env 一覧・実行方法・安全注意。kako-jun の手作業はリポ作成と PAT 発行の 2 つだけ。

## 検証状況
- env 無しで `npm test` → **216 通常テスト緑 + e2e 往復 3 件 skipped + sanity 1 件 green**（合計 217 passed / 3 skipped）。
- `npm run lint`（prettier + svelte-check）0 エラー、typecheck 0 エラー。
- **本番コード（src/lib/**）は不変**（diff は test / docs / package.json script のみ）。
- ⚠️ **実 GitHub に対する pass は未検証**（fixture リポ/トークンが未用意のため）。env を用意して走らせ、落ちたら追って直す前提。型・公開 API 整合・env 無しでの skip までは保証済み（この旨は test 冒頭 doc と runbook にも明記）。