### PR TITLE
fix: 長文トーストをモバイルで折り返して見切れを解消 (#253)

### DIFF
--- a/src/components/layout/Toast.svelte
+++ b/src/components/layout/Toast.svelte
@@ -71,12 +71,12 @@
     min-width: 140px;
     max-width: calc(100vw - 24px);
     text-align: center;
-    white-space: nowrap;
+    overflow-wrap: anywhere;
     text-shadow: 1px 1px 2px rgba(255, 255, 255, 0.8);
     display: flex;
     align-items: center;
     justify-content: center;
-    line-height: 1;
+    line-height: 1.4;
   }
 
   /* #238: FF 風カウントダウン付きの2行レイアウト */


### PR DESCRIPTION
## 関連 Issue
closes #253

## 問題
Push 関連の長文トースト（`pushLateSuccess`「遅れていたPushの成功を確認しました。同期状態を回復しました」・`pushTimeout` 等）が、モバイル幅で**左右が見切れて読めない**（kako-jun 実機報告）。

## 原因
`src/components/layout/Toast.svelte` の `.toast` に `white-space: nowrap` が効いており、`max-width: calc(100vw - 24px)` で頭打ちなのに折り返せず、中央寄せのため長文が両端にこぼれていた。

## 修正（`.toast` の CSS 2行のみ）
- `white-space: nowrap` → `overflow-wrap: anywhere`（flex アイテムの min-content 溢れも止める。`break-word` でなく `anywhere` を選択）
- `line-height: 1` → `1.4`（折り返し時の行重なり防止）

`.toast.with-countdown`（#238 カウントダウン2行）は詳細度・定義順とも独自 `line-height:1.2` が勝ち無影響。短文・カウントダウンは max-width 内で折り返し未発火＝1行のまま不変。

## 検証
- `npm run lint` 0 errors。独立レビューで Approve（回帰なし）
- **見た目サインオフは実機**: kako-jun がモバイル幅で長文トーストの折り返し・両端収まり、短文/カウントダウンの不変を目視（ヘッドレス不可環境のため）