### PR TITLE
fix: 改行コードCRLFのリーフで全行がガターdirtyになる不具合を修正 (#199)

### DIFF
--- a/docs/development/ui/dirty-line-marker.md
+++ b/docs/development/ui/dirty-line-marker.md
@@ -70,14 +70,19 @@ const getBaseContent = () => getLastPushedContent(leafId)
 基準と現在の行配列でLCSを計算し、LCSに含まれない行をダーティとしてマークする。
 単純な行番号比較では行の挿入/削除で後続行が全てダーティになるが、LCSなら順序を保持した共通部分を正しく検出できる。
 
+**改行コード正規化**: CodeMirror は doc を常に LF 化する一方、ベースライン（`getLastPushedContent()`）は原文の CRLF を保持するため、両者を関数冒頭で `\r\n?` → `\n` に正準化してから比較・split し、改行コード差だけで全行が誤ってダーティになるのを防ぐ（#199）。
+
 ```typescript
 export function computeDirtyLines(baseContent: string | null, currentContent: string): Set<number> {
+  // 改行コードをLFに正準化してから比較・split する（#199）
+  const b = baseContent === null ? null : baseContent.replace(/\r\n?/g, '\n')
+  const c = currentContent.replace(/\r\n?/g, '\n')
   // 基準がnull = 新規リーフ → 全行がダーティ
-  if (baseContent === null) {
+  if (b === null) {
     // 全行を追加
   }
-  const baseLines = baseContent.split('\n')
-  const currentLines = currentContent.split('\n')
+  const baseLines = b.split('\n')
+  const currentLines = c.split('\n')
   // LCSを計算し、LCSに含まれない行をダーティとしてマーク
   const lcsIndices = computeLCS(baseLines, currentLines)
   // lcsIndicesに含まれない行 → ダーティ

--- a/src/lib/editor/dirty-lines.test.ts
+++ b/src/lib/editor/dirty-lines.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #199: computeDirtyLines の改行コード正規化と dirty 行判定の回帰防止テスト。
+ *
+ * baseContent（Push 済みの保存内容）が CRLF / 単独 CR を含む一方で、
+ * CodeMirror の doc は常に LF のため、改行コード差だけで全行が誤 dirty に
+ * なるバグ（#199）を直した。ここでは正規化が入っても既存の LCS 判定
+ * （内容差・挿入/削除・base===null・完全一致）が壊れていないことも併せて縛る。
+ *
+ * computeDirtyLines は純関数なので DOM 依存なしにそのまま import してテストする。
+ */
+import { describe, expect, it } from 'vitest'
+import { computeDirtyLines } from './dirty-lines'
+
+describe('computeDirtyLines 改行コード正規化（回帰 #199）', () => {
+  it('CRLF の base と LF の current は改行差だけなら空 Set（核心の回帰）', () => {
+    expect(computeDirtyLines('a\r\nb\r\nc', 'a\nb\nc')).toEqual(new Set())
+  })
+
+  it('逆向き: LF の base と CRLF の current も改行差だけなら空 Set', () => {
+    expect(computeDirtyLines('a\nb', 'a\r\nb')).toEqual(new Set())
+  })
+
+  it('旧 Mac の単独 CR も LF と一致扱いで空 Set', () => {
+    expect(computeDirtyLines('a\rb', 'a\nb')).toEqual(new Set())
+  })
+
+  it('base 内に CRLF・LF・単独 CR が混在していても LF 化して比較し空 Set', () => {
+    expect(computeDirtyLines('a\r\nb\nc\rd', 'a\nb\nc\nd')).toEqual(new Set())
+  })
+
+  it('改行正規化と内容差が同居: 改行差の行は clean・内容差の行だけ dirty', () => {
+    // base/current とも CRLF だが 2 行目だけ内容が違う → 2 行目のみ dirty
+    expect(computeDirtyLines('a\r\nb\r\nc', 'a\r\nB\r\nc')).toEqual(new Set([2]))
+  })
+})
+
+describe('computeDirtyLines 内容差の判定（退行防止）', () => {
+  it('改行差のみの 1 行目は clean・内容差の 2 行目だけ dirty', () => {
+    // base=CRLF / current=LF かつ 2 行目の中身が b→B
+    expect(computeDirtyLines('a\r\nb', 'a\nB')).toEqual(new Set([2]))
+  })
+
+  it('複数行のうち中身が変わった行だけ dirty になる', () => {
+    expect(computeDirtyLines('line1\nline2\nline3', 'line1\nCHANGED\nline3')).toEqual(new Set([2]))
+  })
+})
+
+describe('computeDirtyLines base === null（新規リーフ）', () => {
+  it('base が null なら全行 dirty（正規化と無関係にこの挙動を維持）', () => {
+    expect(computeDirtyLines(null, 'a\nb\nc')).toEqual(new Set([1, 2, 3]))
+  })
+
+  it('base が null かつ current が空文字なら 1 行目（空行）が dirty', () => {
+    expect(computeDirtyLines(null, '')).toEqual(new Set([1]))
+  })
+
+  it('base が null でも current 側の単独 CR を LF 化してから行数を数える', () => {
+    // 正規化されなければ "a\rb" は 1 行扱い {1} になってしまう
+    expect(computeDirtyLines(null, 'a\rb')).toEqual(new Set([1, 2]))
+  })
+})
+
+describe('computeDirtyLines 完全一致（LCS スキップ経路）', () => {
+  it('正規化後に base===current なら空 Set', () => {
+    expect(computeDirtyLines('a\nb\nc', 'a\nb\nc')).toEqual(new Set())
+  })
+
+  it('両方とも空文字なら空 Set', () => {
+    expect(computeDirtyLines('', '')).toEqual(new Set())
+  })
+})
+
+describe('computeDirtyLines エッジ（正規化が LCS を壊していないこと）', () => {
+  it('空 base に 1 行入力すると 1 行目が dirty', () => {
+    expect(computeDirtyLines('', 'a')).toEqual(new Set([1]))
+  })
+
+  it('行を挿入すると挿入行だけ dirty になる', () => {
+    // "a\nc" に "b" を 2 行目として挿入
+    expect(computeDirtyLines('a\nc', 'a\nb\nc')).toEqual(new Set([2]))
+  })
+
+  it('行を削除しても残った行は全て clean（dirty 行なし）', () => {
+    // 中間行 "b" を削除。残る current 行は base の LCS に全て含まれる
+    expect(computeDirtyLines('a\nb\nc', 'a\nc')).toEqual(new Set())
+  })
+
+  it('末尾改行を付けると新しく生えた末尾の空行だけ dirty', () => {
+    expect(computeDirtyLines('a', 'a\n')).toEqual(new Set([2]))
+  })
+
+  it('末尾改行を消しても残る 1 行は clean（dirty 行なし）', () => {
+    expect(computeDirtyLines('a\n', 'a')).toEqual(new Set())
+  })
+})

--- a/src/lib/editor/dirty-lines.ts
+++ b/src/lib/editor/dirty-lines.ts
@@ -73,9 +73,13 @@ function computeLCS(baseLines: string[], currentLines: string[]): Set<number> {
 export function computeDirtyLines(baseContent: string | null, currentContent: string): Set<number> {
   const dirtyLines = new Set<number>()
 
+  // CodeMirror は doc を常に LF 化するため、ベースラインも LF に正準化して改行コード差での誤 dirty を防ぐ（#199）
+  const b = baseContent === null ? null : baseContent.replace(/\r\n?/g, '\n')
+  const c = currentContent.replace(/\r\n?/g, '\n')
+
   // 基準がnull = 新規リーフ → 全行がダーティ
-  if (baseContent === null) {
-    const lines = currentContent.split('\n')
+  if (b === null) {
+    const lines = c.split('\n')
     for (let i = 1; i <= lines.length; i++) {
       dirtyLines.add(i)
     }
@@ -83,12 +87,12 @@ export function computeDirtyLines(baseContent: string | null, currentContent: st
   }
 
   // 完全一致なら LCS をスキップ（O(n*m) を回避）
-  if (baseContent === currentContent) {
+  if (b === c) {
     return dirtyLines
   }
 
-  const baseLines = baseContent.split('\n')
-  const currentLines = currentContent.split('\n')
+  const baseLines = b.split('\n')
+  const currentLines = c.split('\n')
 
   // LCSを計算して、LCSに含まれない行をダーティとしてマーク
   const lcsIndices = computeLCS(baseLines, currentLines)


### PR DESCRIPTION
## 関連 Issue
closes #199

## 症状
アーカイブ済み SimpleNote リーフを開いただけで（編集していないのに）行にガター dirty が付く。

## 根本原因
CodeMirror 6 は doc を常に LF 化する（DefaultSplit `/\r\n?|\n/`、`lineSeparator` facet 未設定）が、行 dirty のベースライン `getLastPushedContent` は原文の CRLF を保持。そのため `computeDirtyLines`（`src/lib/editor/dirty-lines.ts`）が `\r\n` 改行のリーフで LCS 全不一致→全行 dirty を誤検知していた。SimpleNote インポートは原文を無加工格納するため Windows 由来 `\r\n` を含むノートだけが該当し、アーカイブ SimpleNote に偏って再現していた。全角カンマ等の文字正規化は無関係（コード上に存在しない）。

## 修正
`computeDirtyLines` 冒頭で `baseContent`/`currentContent` を `.replace(/\r\n?/g, '\n')` で LF 正準化してから比較・split する。`/\r\n?/g` は CRLF・単独CR（旧Mac）双方を畳み、CodeMirror の DefaultSplit と挙動が一致。表示（ガター判定）専用の純関数一点の変更で、保存データ・Push・title同期・`detectDirtyIds`（生比較）には触れない＝原文尊重。

## テスト
`src/lib/editor/dirty-lines.test.ts` を新規追加（17ケース）:
- 回帰核心: CRLF base × LF current → dirty 無し（逆向き・単独CR・混在改行も）
- 退行防止: 改行差は clean・**内容差の行だけ** dirty
- 既存挙動維持: base=null（新規リーフ）全行 dirty、行挿入/削除/末尾改行の LCS 判定
- 全 17 passed。既存スイートも green（回帰なし）

## 完了条件（実機サインオフ）
CRLF 改行を含むアーカイブ SimpleNote リーフを開いても、編集していなければガター dirty が付かないこと。