### PR TITLE
fix: リポ切替後の表示を新repoのクリーンなhomeへ収束させる (#147)

### DIFF
--- a/docs/development/sync/push-pull.md
+++ b/docs/development/sync/push-pull.md
@@ -625,6 +625,7 @@ sequenceDiagram
     HSC->>HSC: githubSettingsChangedInSettings = true
     HSC->>HSC: isPullCompleted = false
     HSC->>HSC: isFirstPriorityFetched = false
+    HSC->>HSC: repoChangePending = true
 
     HSC->>RFRS: resetForRepoSwitch()
     Note over RFRS: 1. resetArchive()<br/>  archiveNotes=[], archiveLeaves=[]<br/>  archiveMetadata=初期値<br/>  isArchiveLoaded=false
@@ -633,6 +634,8 @@ sequenceDiagram
     Note over RFRS: 4. clearAllChanges()<br/>  isStructureDirty=false<br/>  dirtyNoteIds=∅, dirtyLeafIds=∅
     Note over RFRS: 5. lastKnownCommitSha は新リポのスロットから<br/>  localStorage 経由で復元（#131）<br/>  lastPulledPushCount=0<br/>  isStale=false<br/>  lastPushTime=0<br/>  lastStaleCheckTime=0
     Note over RFRS: 6. leftWorld='home'<br/>  rightWorld='home'
+
+    HSC->>HSC: window.history.replaceState(state, '', pathname)<br/>URL query をクリア（旧パスと同名のノート/リーフが<br/>新リポにあると pull 後の restoreStateFromUrl が<br/>誤着地するのを防ぐ）<br/>history.state は保持
 
     User->>Settings: 設定画面を閉じる（×ボタン）
     Settings->>HCS: onClose()
@@ -643,18 +646,21 @@ sequenceDiagram
         HCS->>PFG: pullFromGitHub(false)
         Note over PFG: canSync OK, isArchiveLoading=false<br/>→ 処理開始
         PFG->>PFG: isPulling = true
+        Note over PFG: isRepoSwitchPull = repoChangePending<br/>（切替起因の印を控えてから repoChangePending=false）
         Note over PFG: isDirty=false（クリア済み）<br/>→ 確認ダイアログなし
         Note over PFG: 新リポが未初出なら lastKnownCommitSha===null<br/>→ 初回Pull扱い<br/>以前開いたリポなら保存済SHAがあり差分Pull可
         PFG->>PFG: clearAllData() + ストアクリア
         PFG->>PFG: executePull()
         Note over PFG: onStructure → notes表示可能<br/>onPriorityComplete →<br/>  isFirstPriorityFetched=true<br/>  isLoadingUI=false
         Note over PFG: 残りのリーフ取得...<br/>isPullCompleted=true
+        Note over PFG: isRepoSwitchPull なら await tick() 後に<br/>.main-pane の scrollTop=0<br/>（旧リポ一覧のスクロール残骸をリセット #147）
         PFG->>PFG: setLastPushedSnapshot()
         PFG->>PFG: lastKnownCommitSha=commitSha
         PFG->>PFG: isPulling = false
         HCS->>HCS: isClosingSettingsPull = false
     else Pull/Push/ArchiveLoad中
-        Note over HCS: 新Pullを発行しない<br/>resetForRepoSwitchで既にクリア済み<br/>次回手動Pull時に新リポからPull
+        Note over HCS: 即時Pullせず pendingRepoSync=true で予約<br/>（repoChangePending は落とさず引き回す）<br/>resetForRepoSwitchで既にクリア済み
+        Note over HCS: 進行中同期の finally 後に queue pull を1回実行<br/>→ pullFromGitHub 入口で isRepoSwitchPull=true<br/>→ scroll 残骸リセットも発火（#147）
     end
 
     HCS->>HCS: repoChangedInSettings = false
@@ -745,17 +751,17 @@ sequenceDiagram
 
 #### Bランク（UX問題 — 動作はするが改善が望ましい）
 
-| #   | 操作シナリオ                           | 期待動作                          | 対応するガード/関数                                                                                               | 深刻度 |
-| --- | -------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- | :----: |
-| 13  | リポ切替直後にアーカイブ切替           | 新リポのアーカイブがPullされる    | `isArchiveLoaded=false` → `handleWorldChange()` → `pullArchive()`                                                 |   B    |
-| 14  | リポ切替連打（A→B→A）                  | 最終的にAのデータが表示される     | 各変更で`resetForRepoSwitch()`が呼ばれ最後の設定が残る。閉じる時に1回だけPull                                     |   B    |
-| 15  | 同じリポ名・トークンを再設定           | 何も起きない（リセット/Pullなし） | `repoChanged`/`tokenChanged`判定で`false` → `handleCloseSettings()`でスキップ                                     |   B    |
-| 15a | トークンだけ変更して閉じる             | Pullが走る（新トークンで再取得）  | `githubSettingsChangedInSettings=true` → `handleCloseSettings()` → `pullFromGitHub()`                             |   B    |
-| 16  | テーマだけ変更して閉じる               | Pullされない                      | `githubSettingsChangedInSettings=false` かつ `importOccurredInSettings=false` → `handleCloseSettings()`でスキップ |   B    |
-| 17  | インポート後にリポ切替なしで閉じる     | インポートデータの同期Pullが走る  | `importOccurredInSettings=true` → `handleCloseSettings()` → `pullFromGitHub()`                                    |   B    |
-| 18  | リポ切替＋インポート両方実行して閉じる | Pullは1回だけ実行される           | `repoChangedInSettings \|\| importOccurredInSettings` → 1回の`pullFromGitHub()`                                   |   B    |
-| 19  | URL状態が旧リポのID参照                | ホームにフォールバック            | `restoreStateFromUrl()` → ID不一致 → ホーム表示                                                                   |   B    |
-| 20  | IndexedDB自動保存が旧データで上書き    | 新リポデータが保持される          | `pullFromGitHub()` → `clearAllData()` → 新データ保存                                                              |   B    |
+| #   | 操作シナリオ                           | 期待動作                          | 対応するガード/関数                                                                                                                                                                                          | 深刻度 |
+| --- | -------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----: |
+| 13  | リポ切替直後にアーカイブ切替           | 新リポのアーカイブがPullされる    | `isArchiveLoaded=false` → `handleWorldChange()` → `pullArchive()`                                                                                                                                            |   B    |
+| 14  | リポ切替連打（A→B→A）                  | 最終的にAのデータが表示される     | 各変更で`resetForRepoSwitch()`が呼ばれ最後の設定が残る。閉じる時に1回だけPull                                                                                                                                |   B    |
+| 15  | 同じリポ名・トークンを再設定           | 何も起きない（リセット/Pullなし） | `repoChanged`/`tokenChanged`判定で`false` → `handleCloseSettings()`でスキップ                                                                                                                                |   B    |
+| 15a | トークンだけ変更して閉じる             | Pullが走る（新トークンで再取得）  | `githubSettingsChangedInSettings=true` → `handleCloseSettings()` → `pullFromGitHub()`                                                                                                                        |   B    |
+| 16  | テーマだけ変更して閉じる               | Pullされない                      | `githubSettingsChangedInSettings=false` かつ `importOccurredInSettings=false` → `handleCloseSettings()`でスキップ                                                                                            |   B    |
+| 17  | インポート後にリポ切替なしで閉じる     | インポートデータの同期Pullが走る  | `importOccurredInSettings=true` → `handleCloseSettings()` → `pullFromGitHub()`                                                                                                                               |   B    |
+| 18  | リポ切替＋インポート両方実行して閉じる | Pullは1回だけ実行される           | `repoChangedInSettings \|\| importOccurredInSettings` → 1回の`pullFromGitHub()`                                                                                                                              |   B    |
+| 19  | URL状態が旧リポのID参照                | ホームに収束（URLがクリア済み）   | リポ切替時に `handleSettingsChange()` が `history.replaceState` で URL query を空にする → `restoreStateFromUrl()` は空URLを読み home へ収束（旧パスと同名のノート/リーフで ID が一致する誤着地も併せて回避） |   B    |
+| 20  | IndexedDB自動保存が旧データで上書き    | 新リポデータが保持される          | `pullFromGitHub()` → `clearAllData()` → 新データ保存                                                                                                                                                         |   B    |
 
 #### Cランク（軽微 — 現在の動作で問題なし）
 

--- a/src/lib/actions/git.test.ts
+++ b/src/lib/actions/git.test.ts
@@ -1,3 +1,7 @@
+// @vitest-environment jsdom
+// #147 綻び2 のスクロールリセットは document.querySelectorAll と実 scrollTop を
+// 触るため jsdom が要る。既存 50 件は node でも jsdom でも全パスすることを確認済み
+// （setImmediate 等の Node グローバルは jsdom 環境でも利用可能）。
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type ValueStore<T> = { value: T }
@@ -42,6 +46,8 @@ const appState = vi.hoisted(() => ({
   selectedIndexRight: 0,
   loadingLeafIds: new Set<string>(),
   leafSkeletonMap: new Map(),
+  // #147 綻び2: リポ切替起因 Pull かの判定に使う（既定は通常 pull=false）
+  repoChangePending: false,
 }))
 
 const mocks = vi.hoisted(() => ({
@@ -1389,5 +1395,130 @@ describe('pullFromGitHub pullIncomplete partial cache (#207)', () => {
 
     expect(mocks.saveLeaves).not.toHaveBeenCalled()
     expect(mocks.saveNotes).not.toHaveBeenCalled()
+  })
+})
+
+describe('pullFromGitHub リポ切替時のスクロールリセット (#147 綻び2)', () => {
+  // Pull 成功分岐まで到達させるための最小成功結果
+  const pullSuccessResult = {
+    success: true,
+    message: 'github.pullSuccess',
+    variant: 'success' as const,
+    notes: [{ id: 'note-1', name: 'Note', parentId: null, order: 0 }],
+    leaves: [{ id: 'leaf-1', noteId: 'note-1', content: 'remote', order: 0 }],
+    metadata: { pushCount: 2 },
+    commitSha: 'remote-sha',
+  }
+
+  /**
+   * app-state.svelte.ts の PWA 復帰修復と同じ .left-column/.right-column 配下に
+   * .main-pane を用意し、初期 scrollTop（非0）を入れて残骸を再現する。
+   */
+  function setupPanes(leftTop: number, rightTop: number) {
+    document.body.innerHTML =
+      '<div class="left-column"><div class="main-pane"></div></div>' +
+      '<div class="right-column"><div class="main-pane"></div></div>'
+    const left = document.querySelector('.left-column .main-pane') as HTMLElement
+    const right = document.querySelector('.right-column .main-pane') as HTMLElement
+    left.scrollTop = leftTop
+    right.scrollTop = rightTop
+    return { left, right }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stores.settings.value = { token: 'token', repoName: 'owner/repo', branch: 'main' }
+    stores.isPulling.value = false
+    stores.isPushing.value = false
+    stores.isPushingBackground.value = false
+    stores.isStale.value = false
+    stores.isDirty.value = false
+    stores.lastKnownCommitSha.value = 'local-sha'
+    stores.lastPushTime.value = 0
+    stores.notes.value = []
+    stores.leaves.value = []
+    appState.isArchiveLoading = false
+    appState.isFirstPriorityFetched = false
+    appState.isPullCompleted = false
+    // #147: このフラグの真偽で scroll reset の発火が決まる（既定は通常 pull=false）
+    appState.repoChangePending = false
+
+    mocks.getPersistedDirtyFlag.mockReturnValue(false)
+    // up_to_date + isPullCompleted の早期 return を避け、実 Pull（success 分岐）へ進める
+    mocks.executeStaleCheck.mockResolvedValue({
+      status: 'stale',
+      localCommitSha: 'local-sha',
+      remoteCommitSha: 'remote-sha',
+    })
+    mocks.saveNotes.mockResolvedValue(undefined)
+    mocks.saveLeaves.mockResolvedValue(undefined)
+    mocks.executePull.mockResolvedValue(pullSuccessResult)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('リポ切替起因（repoChangePending=true）の Pull 成功で両 .main-pane の scrollTop が 0 になる', async () => {
+    appState.repoChangePending = true
+    const { left, right } = setupPanes(300, 150)
+
+    await pullFromGitHub(false)
+
+    expect(mocks.executePull).toHaveBeenCalledTimes(1)
+    expect(left.scrollTop).toBe(0)
+    expect(right.scrollTop).toBe(0)
+  })
+
+  it('不発火（デグレ防止の核心）: 通常 Pull（repoChangePending=false）成功では .main-pane の scrollTop に触れない', async () => {
+    // deep-link 復元でスクロールが飛ばないことを縛る。成功しても scroll は残す。
+    appState.repoChangePending = false
+    const { left, right } = setupPanes(300, 150)
+
+    await pullFromGitHub(false)
+
+    expect(mocks.executePull).toHaveBeenCalledTimes(1)
+    expect(left.scrollTop).toBe(300)
+    expect(right.scrollTop).toBe(150)
+  })
+
+  it('入口で控えた isRepoSwitchPull は Pull 中に repoChangePending が false 化されても保持され、成功時に scroll reset が走る', async () => {
+    // repoChangePending は pullFromGitHub 入口直後で false 化される（進捗%へ交代）。
+    // scroll reset が「成功時点の live フラグ」でなく「入口で控えた const」で
+    // 判定されることを縛る（＝false 化後でも reset が走る）。
+    appState.repoChangePending = true
+    const { left, right } = setupPanes(300, 150)
+
+    let pendingAtExecutePull: boolean | undefined
+    mocks.executePull.mockImplementation(async () => {
+      // executePull 到達時点では repoChangePending は既に落ちている
+      pendingAtExecutePull = appState.repoChangePending
+      return pullSuccessResult
+    })
+
+    await pullFromGitHub(false)
+
+    expect(pendingAtExecutePull).toBe(false)
+    // それでも入口 const 由来で scroll reset は走る
+    expect(left.scrollTop).toBe(0)
+    expect(right.scrollTop).toBe(0)
+  })
+
+  it('リポ切替起因でも Pull が失敗（success:false）なら scroll には触れない（reset は success 分岐内）', async () => {
+    appState.repoChangePending = true
+    const { left, right } = setupPanes(300, 150)
+    mocks.executePull.mockResolvedValue({
+      success: false,
+      message: 'github.pullFailed',
+      variant: 'error' as const,
+      notes: [],
+      leaves: [],
+      metadata: { pushCount: 2 },
+    })
+
+    await pullFromGitHub(false)
+
+    expect(left.scrollTop).toBe(300)
+    expect(right.scrollTop).toBe(150)
   })
 })

--- a/src/lib/actions/git.ts
+++ b/src/lib/actions/git.ts
@@ -642,6 +642,11 @@ export async function pullFromGitHub(
 
   // 即座にロック取得（この後の非同期処理中にPushが開始されるのを防止）
   isPulling.value = true
+  // #147 綻び2: この Pull がリポ切替起因かを、直後にフラグが落ちる前に控える。
+  // repoChangePending は handleSettingsChange の repo 切替検知でのみ true になり、
+  // 通常 pull（F5・同期・deep-link 復元・起動時）では false のため、この控えは
+  // 「リポ切替による pull かどうか」を安全に表す（下のスクロール残骸リセット判定に使う）。
+  const isRepoSwitchPull = appState.repoChangePending
   // pull開始と同時に「pull予約あり」バッジを落とす（進捗%に交代）
   appState.repoChangePending = false
   try {
@@ -811,6 +816,21 @@ export async function pullFromGitHub(
       appState.isPullCompleted = true
       appState.selectedIndexLeft = 0
       appState.selectedIndexRight = 0
+
+      // #147 綻び2: リポ切替起因の Pull のときだけ、旧リポの一覧で残った
+      // スクロール位置をリセットする。home→home では HomeView が remount されず
+      // .main-pane の scrollTop が残るため。selectedIndex=0 は全 pull 成功で走るが、
+      // scroll リセットは切替時に限定する（通常 pull で発火すると deep-link 復元時に
+      // スクロールが飛ぶデグレになる）。.main-pane の参照は app-state.svelte.ts の
+      // PWA 復帰レイアウト修復と同じ .left-column/.right-column 配下セレクタに合わせる。
+      if (isRepoSwitchPull) {
+        await tick()
+        document
+          .querySelectorAll('.left-column .main-pane, .right-column .main-pane')
+          .forEach((el) => {
+            ;(el as HTMLElement).scrollTop = 0
+          })
+      }
 
       const currentLeaves = leaves.value
       const currentLeafMap = new Map(currentLeaves.map((l) => [l.id, l]))

--- a/src/lib/actions/git.ts
+++ b/src/lib/actions/git.ts
@@ -646,6 +646,10 @@ export async function pullFromGitHub(
   // repoChangePending は handleSettingsChange の repo 切替検知でのみ true になり、
   // 通常 pull（F5・同期・deep-link 復元・起動時）では false のため、この控えは
   // 「リポ切替による pull かどうか」を安全に表す（下のスクロール残骸リセット判定に使う）。
+  // queue 経由の切替（同期ビジー中に切替 → 予約 pull）でも印は引き回される:
+  // handleCloseSettings は pendingRepoSync=true のとき repoChangePending を落とさず
+  // 予約 pull の入口（ここ）まで残す。よって repoChangePending 単体で false 化される
+  // ことはなく（direct pull は入口で消費、queue pull は入口まで保持）、両経路で発火する。
   const isRepoSwitchPull = appState.repoChangePending
   // pull開始と同時に「pull予約あり」バッジを落とす（進捗%に交代）
   appState.repoChangePending = false

--- a/src/lib/pane-actions-factory.dom.test.ts
+++ b/src/lib/pane-actions-factory.dom.test.ts
@@ -151,6 +151,27 @@ describe('handleSettingsChange の URL query クリア (#147 綻び1)', () => {
     expect(appState.repoChangePending).toBe(true)
     expect(window.location.search).toBe('')
   })
+
+  // #147 Q1: query を落とす際に history.state を保持する（{} で潰さない）。
+  // top エントリの state には PWA exit guard 等が積んだキーが載っており、{} で
+  // 上書きすると popstate のガード検出（e.state?.[PWA_EXIT_GUARD_KEY]）が壊れる。
+  // 上の他テストは setup が state={} のため replaceState({}, …) の旧コードでも通って
+  // しまい Q1 を縛れない。ここでは非空 state を積み、その同一 state で replaceState が
+  // 呼ばれる（＝第1引数が {} でない）ことを縛って旧コードへの退行を検知する。
+  it('Q1: 非空の history.state を保持したまま URL query だけ落とす（replaceState({}) 退行検知）', () => {
+    const guardState = { 'pwa-exit-guard': true }
+    // seed 呼び出しは call-through で history.state を更新するが観測対象外にする
+    window.history.replaceState(guardState, '', '/notes/shared-name?leaf=old-leaf')
+    replaceStateSpy.mockClear()
+
+    handleSettingsChange({ repoName: 'owner/new-repo' })
+
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1)
+    // 第1引数が {} でなく元の state であることが Q1 の核心（旧コードだとここで落ちる）
+    expect(replaceStateSpy).toHaveBeenCalledWith(guardState, '', '/notes/shared-name')
+    expect(window.history.state).toEqual(guardState)
+    expect(window.location.search).toBe('')
+  })
 })
 
 /**

--- a/src/lib/pane-actions-factory.dom.test.ts
+++ b/src/lib/pane-actions-factory.dom.test.ts
@@ -28,7 +28,9 @@ const appState = vi.hoisted(() => ({
   isFirstPriorityFetched: true,
   isArchiveLoading: false,
   repoChangePending: false,
+  pendingRepoSync: false,
   pendingRehydrateRepo: null as string | null,
+  importOccurredInSettings: false,
 }))
 
 const mocks = vi.hoisted(() => ({
@@ -37,6 +39,9 @@ const mocks = vi.hoisted(() => ({
   rehydrateForRepo: vi.fn(async () => {}),
   archiveReset: vi.fn(),
   applyTheme: vi.fn(),
+  // handleCloseSettings の queue/idle 分岐を制御する（既定 undefined=falsy=idle）
+  shouldQueueRepoSync: vi.fn(),
+  pullFromGitHub: vi.fn(async () => {}),
 }))
 
 // handleSettingsChange が実際に触るモジュールだけ実体スタブを与える
@@ -72,17 +77,17 @@ vi.mock('./ui', () => ({
 // handleSettingsChange が呼ばない兄弟モジュールは実評価だけ止める（空モック）
 vi.mock('./i18n', () => ({ _: { subscribe: () => () => {} } }))
 vi.mock('svelte-i18n', () => ({ locale: { subscribe: () => () => {} } }))
-vi.mock('./sync/repo-sync-queue', () => ({ shouldQueueRepoSync: vi.fn() }))
+vi.mock('./sync/repo-sync-queue', () => ({ shouldQueueRepoSync: mocks.shouldQueueRepoSync }))
 vi.mock('./pane-navigation.svelte', () => ({}))
 vi.mock('./navigation', () => ({}))
-vi.mock('./actions/git', () => ({}))
+vi.mock('./actions/git', () => ({ pullFromGitHub: mocks.pullFromGitHub }))
 vi.mock('./actions/crud', () => ({}))
 vi.mock('./actions/move', () => ({}))
 vi.mock('./actions/io', () => ({}))
 vi.mock('./utils', () => ({}))
 vi.mock('./data', () => ({}))
 
-const { handleSettingsChange } = await import('./pane-actions-factory.svelte')
+const { handleSettingsChange, handleCloseSettings } = await import('./pane-actions-factory.svelte')
 
 describe('handleSettingsChange の URL query クリア (#147 綻び1)', () => {
   let replaceStateSpy: ReturnType<typeof vi.spyOn>
@@ -145,5 +150,65 @@ describe('handleSettingsChange の URL query クリア (#147 綻び1)', () => {
     expect(mocks.resetForRepoSwitch).toHaveBeenCalledTimes(1)
     expect(appState.repoChangePending).toBe(true)
     expect(window.location.search).toBe('')
+  })
+})
+
+/**
+ * handleCloseSettings の「queue 経由の切替でも scroll reset の印を引き回す」テスト（#147 綻び2 / S1）
+ *
+ * 同期ビジー中にリポ切替 → close すると予約 pull（pendingRepoSync=true）に載る。
+ * このとき repoChangePending を落とすと、予約 pull の入口（git.ts pullFromGitHub）が
+ * isRepoSwitchPull を拾えず scroll reset が不発になる（S1 の取りこぼし）。
+ * handleCloseSettings が pendingRepoSync=true のとき repoChangePending を保持することを縛る。
+ * repoChangePending=true → scroll reset 発火は git.test.ts 側で別途縛っている。
+ */
+describe('handleCloseSettings queue 経由切替の scroll reset 印引き回し (#147 綻び2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stores.settings.value = { token: 'token', repoName: 'owner/repo', branch: 'main' }
+    stores.isPulling.value = false
+    stores.isPushing.value = false
+    // 同期ビジー（背景 Push 中）を再現。handleSettingsChange 側の syncBusy 判定にも効く
+    stores.isPushingBackground.value = true
+    appState.isPullCompleted = true
+    appState.isFirstPriorityFetched = true
+    appState.isArchiveLoading = false
+    appState.repoChangePending = false
+    appState.pendingRepoSync = false
+    appState.pendingRehydrateRepo = null
+    appState.importOccurredInSettings = false
+    mocks.rehydrateForRepo.mockResolvedValue(undefined)
+  })
+
+  it('queue 経由のリポ切替では予約 pull（pendingRepoSync）に載せつつ repoChangePending を落とさない', async () => {
+    // 同期ビジー → close で queue 分岐に入る
+    mocks.shouldQueueRepoSync.mockReturnValue(true)
+
+    handleSettingsChange({ repoName: 'owner/new-repo' })
+    // 切替検知で予約バッジが立ち、pull 未完了に戻る
+    expect(appState.repoChangePending).toBe(true)
+    expect(appState.isPullCompleted).toBe(false)
+
+    await handleCloseSettings()
+
+    // 予約 pull に載る。直接 pull は走らない
+    expect(appState.pendingRepoSync).toBe(true)
+    expect(mocks.pullFromGitHub).not.toHaveBeenCalled()
+    // S1 の核心: 予約 pull の入口まで切替印が残る（従来はここで false 化して取りこぼしていた）
+    expect(appState.repoChangePending).toBe(true)
+  })
+
+  it('不発火（通常 pull デグレ防止）: token 変更で queue した場合は切替印を立てない', async () => {
+    mocks.shouldQueueRepoSync.mockReturnValue(true)
+
+    handleSettingsChange({ token: 'new-token' })
+    // token 変更はリポ切替ではないので repoChangePending は立たない
+    expect(appState.repoChangePending).toBe(false)
+
+    await handleCloseSettings()
+
+    // queue には載るが、切替印は付かない → 予約 pull で scroll reset は起きない
+    expect(appState.pendingRepoSync).toBe(true)
+    expect(appState.repoChangePending).toBe(false)
   })
 })

--- a/src/lib/pane-actions-factory.dom.test.ts
+++ b/src/lib/pane-actions-factory.dom.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+/**
+ * handleSettingsChange の URL query クリア（#147 綻び1）のテスト
+ *
+ * リポ切替検知時のみ window.history.replaceState で query を落とし、通常操作
+ * （テーマ変更・同一 repoName）では URL に触れないことを縛る。旧 URL のパスと
+ * 同名のノート/リーフが新リポにあると、pull 後の restoreStateFromUrl が誤解決して
+ * home でなく誤ったノートに着地する回帰を防ぐ不変条件。
+ *
+ * pane-actions-factory は多数のモジュールを import するため、handleSettingsChange が
+ * 実際に触る ./stores / ./app-state.svelte / ./ui だけ実体スタブを与え、残りの兄弟
+ * モジュールは空モックで実評価を止める（git.test.ts の vi.hoisted + vi.mock 流儀に合わせる）。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const stores = vi.hoisted(() => {
+  const createStore = <T>(value: T) => ({ value })
+  return {
+    settings: createStore({ token: 'token', repoName: 'owner/repo', branch: 'main' }),
+    isPulling: createStore(false),
+    isPushing: createStore(false),
+    isPushingBackground: createStore(false),
+  }
+})
+
+const appState = vi.hoisted(() => ({
+  isPullCompleted: true,
+  isFirstPriorityFetched: true,
+  isArchiveLoading: false,
+  repoChangePending: false,
+  pendingRehydrateRepo: null as string | null,
+}))
+
+const mocks = vi.hoisted(() => ({
+  updateSettings: vi.fn(),
+  resetForRepoSwitch: vi.fn(),
+  rehydrateForRepo: vi.fn(async () => {}),
+  archiveReset: vi.fn(),
+  applyTheme: vi.fn(),
+}))
+
+// handleSettingsChange が実際に触るモジュールだけ実体スタブを与える
+vi.mock('./stores', () => ({
+  settings: stores.settings,
+  isPulling: stores.isPulling,
+  isPushing: stores.isPushing,
+  isPushingBackground: stores.isPushingBackground,
+  updateSettings: mocks.updateSettings,
+  resetForRepoSwitch: mocks.resetForRepoSwitch,
+  rehydrateForRepo: mocks.rehydrateForRepo,
+  archiveLeafStatsStore: { reset: mocks.archiveReset },
+}))
+
+vi.mock('./app-state.svelte', () => ({
+  appState,
+  derivedState: {},
+  registerAppActions: vi.fn(),
+  getNotesForWorld: vi.fn(),
+  getLeavesForWorld: vi.fn(),
+  getWorldForNote: vi.fn(),
+  getWorldForLeaf: vi.fn(),
+  setNotesForWorld: vi.fn(),
+  setLeavesForWorld: vi.fn(),
+}))
+
+vi.mock('./ui', () => ({
+  applyTheme: mocks.applyTheme,
+  showPrompt: vi.fn(),
+  showConfirm: vi.fn(),
+}))
+
+// handleSettingsChange が呼ばない兄弟モジュールは実評価だけ止める（空モック）
+vi.mock('./i18n', () => ({ _: { subscribe: () => () => {} } }))
+vi.mock('svelte-i18n', () => ({ locale: { subscribe: () => () => {} } }))
+vi.mock('./sync/repo-sync-queue', () => ({ shouldQueueRepoSync: vi.fn() }))
+vi.mock('./pane-navigation.svelte', () => ({}))
+vi.mock('./navigation', () => ({}))
+vi.mock('./actions/git', () => ({}))
+vi.mock('./actions/crud', () => ({}))
+vi.mock('./actions/move', () => ({}))
+vi.mock('./actions/io', () => ({}))
+vi.mock('./utils', () => ({}))
+vi.mock('./data', () => ({}))
+
+const { handleSettingsChange } = await import('./pane-actions-factory.svelte')
+
+describe('handleSettingsChange の URL query クリア (#147 綻び1)', () => {
+  let replaceStateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stores.settings.value = { token: 'token', repoName: 'owner/repo', branch: 'main' }
+    stores.isPulling.value = false
+    stores.isPushing.value = false
+    stores.isPushingBackground.value = false
+    appState.isPullCompleted = true
+    appState.isFirstPriorityFetched = true
+    appState.isArchiveLoading = false
+    appState.repoChangePending = false
+    appState.pendingRehydrateRepo = null
+    mocks.rehydrateForRepo.mockResolvedValue(undefined)
+    // 旧 URL に query が載った状態（deep-link 着地後・設定オープン前）を用意する。
+    // このセットアップ自身の replaceState は観測対象外にするため、spy はこの後に張る。
+    window.history.replaceState({}, '', '/notes/shared-name?leaf=old-leaf&x=1')
+    replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+  })
+
+  afterEach(() => {
+    replaceStateSpy.mockRestore()
+  })
+
+  it('リポ切替（repoName が現在と異なる）で replaceState が pathname のみ（query なし）で呼ばれ、search が空になる', () => {
+    handleSettingsChange({ repoName: 'owner/new-repo' })
+
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1)
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/notes/shared-name')
+    // 旧 query を保持しない＝新リポで同名パスを誤解決せず home へ収束できる
+    expect(window.location.search).toBe('')
+    expect(window.location.pathname).toBe('/notes/shared-name')
+  })
+
+  it('不発火: テーマだけ変更（repoName 未指定）では replaceState を呼ばず query を保持する', () => {
+    handleSettingsChange({ theme: 'greenboard' })
+
+    expect(replaceStateSpy).not.toHaveBeenCalled()
+    // 通常操作では URL に触れない（deep-link 状態を壊さない）
+    expect(window.location.search).toBe('?leaf=old-leaf&x=1')
+    // テーマ適用自体は走る（回帰確認）
+    expect(mocks.applyTheme).toHaveBeenCalledTimes(1)
+  })
+
+  it('不発火: repoName が現在と同一（変化なし）では replaceState を呼ばず query を保持する', () => {
+    handleSettingsChange({ repoName: 'owner/repo' })
+
+    expect(replaceStateSpy).not.toHaveBeenCalled()
+    expect(window.location.search).toBe('?leaf=old-leaf&x=1')
+    // repo 切替検知に至らないので切替副作用も走らない
+    expect(mocks.resetForRepoSwitch).not.toHaveBeenCalled()
+    expect(appState.repoChangePending).toBe(false)
+  })
+
+  it('リポ切替では切替副作用（resetForRepoSwitch / repoChangePending）と URL クリアが揃って走る', () => {
+    handleSettingsChange({ repoName: 'owner/new-repo' })
+
+    expect(mocks.resetForRepoSwitch).toHaveBeenCalledTimes(1)
+    expect(appState.repoChangePending).toBe(true)
+    expect(window.location.search).toBe('')
+  })
+})

--- a/src/lib/pane-actions-factory.svelte.ts
+++ b/src/lib/pane-actions-factory.svelte.ts
@@ -481,8 +481,17 @@ export async function handleCloseSettings() {
     // pull失敗または設定が不完全 → 初回pull前の状態に戻す
     if (!appState.isPullCompleted) {
       appState.isFirstPriorityFetched = false
-      // pull失敗時も青丸を残さない（「予約中」の見かけのまま永続するのを防ぐ）
-      appState.repoChangePending = false
+      // pull失敗時も青丸を残さない（「予約中」の見かけのまま永続するのを防ぐ）。
+      // ただし pull を queue した場合（pendingRepoSync=true）は落とさない: この
+      // repoChangePending はリポ切替でのみ立つ「予約 pull が切替起因」の印で、
+      // queue 経由の pull 入口（git.ts pullFromGitHub）が isRepoSwitchPull として
+      // 消費しスクロール残骸をリセットする（#147 綻び2）。ここで落とすと queue 経路の
+      // 切替でリセットが不発になる。予約中のバッジは pendingRepoSync 側が担保するので
+      // 見た目は変わらない（App.svelte の pendingPull は両者の OR）。切替以外で queue
+      // した場合（token 変更・import）は repoChangePending がそもそも false なので影響なし。
+      if (!appState.pendingRepoSync) {
+        appState.repoChangePending = false
+      }
       resetForRepoSwitch()
       archiveLeafStatsStore.reset()
     }

--- a/src/lib/pane-actions-factory.svelte.ts
+++ b/src/lib/pane-actions-factory.svelte.ts
@@ -393,6 +393,12 @@ export function handleSettingsChange(payload: Partial<typeof settings.value>) {
     appState.isFirstPriorityFetched = false
     appState.repoChangePending = true
     resetForRepoSwitch()
+    // #147 綻び1: リポ切替時のみ URL の query を落とす。旧 URL のパスと同名の
+    // ルートノート/リーフが新リポにあると、pull 後の restoreStateFromUrl
+    // （window.location.search を読む）がそれを解決して home でなく誤ったノート/
+    // リーフに着地する。query を空にすれば旧パスを拾わず必ず home へ収束する。
+    // 通常 pull（同期・F5・deep-link 復元）では repoChanged 検知に至らないため発火しない。
+    window.history.replaceState({}, '', window.location.pathname)
   }
 
   updateSettings(next)

--- a/src/lib/pane-actions-factory.svelte.ts
+++ b/src/lib/pane-actions-factory.svelte.ts
@@ -398,7 +398,9 @@ export function handleSettingsChange(payload: Partial<typeof settings.value>) {
     // （window.location.search を読む）がそれを解決して home でなく誤ったノート/
     // リーフに着地する。query を空にすれば旧パスを拾わず必ず home へ収束する。
     // 通常 pull（同期・F5・deep-link 復元）では repoChanged 検知に至らないため発火しない。
-    window.history.replaceState({}, '', window.location.pathname)
+    // history.state は保持したまま URL の query/hash だけ落とす（{} で潰すと
+    // PWA exit guard 等が積んだ history.state を壊す）。
+    window.history.replaceState(window.history.state, '', window.location.pathname)
   }
 
   updateSettings(next)


### PR DESCRIPTION
## 関連 Issue
closes #147

## 背景
home 収束自体は #145 の二重機構（切替時 resetForRepoSwitch で両ペイン'home'、pull後 restoreStateFromUrl→home、selectedIndex=0）で既に達成済み。本 PR は残る2つの「クリーンさ」の綻びを**リポ切替時のみに限定**して潰す。無条件の home 化・URL クリアは通常 pull（F5・同期・deep-link 復元）の状態復元をデグレさせるため、すべて切替経路限定でガードした。

## 変更
### 綻び1: 同名衝突（URL query クリア）
新 repo に旧 URL パスと同名のルートノート/リーフがあると、pull 後の `restoreStateFromUrl` がそれを解決して home でなく誤ったノート/リーフに着地していた。`handleSettingsChange` の repo 切替検知ブロックで `window.history.replaceState(window.history.state, '', location.pathname)` を実行し URL query を落とす（history.state は保持＝PWA exit guard 等を壊さない）。

### 綻び2: スクロール残骸（切替時のみ scrollTop リセット）
旧 repo で一覧をスクロールしたまま切替えると home→home で HomeView が remount されず `.main-pane` の scrollTop が残っていた。`pullFromGitHub` 入口で `isRepoSwitchPull = repoChangePending` を控え、pull 成功時に切替起因なら `await tick()` 後に両ペインの `.main-pane` を scrollTop=0。
- **直販経路＋queue 経路の両方**で発火: 同期ビジー中の切替は pull が queue されるため、`handleCloseSettings` で `repoChangePending`（切替専用フラグ）を `pendingRepoSync` 時に落とさず、queue pull 入口まで引き回す。token 変更・import による queue（repoChangePending=false）では発火しない。

## デグレ防止
- URLクリア・スクロールリセットは共に切替経路限定。通常 pull・auto-pull・deep-link 復元・起動時 pull では発火しない（テストで発火/不発火の対を lock、ミューテーションで非トートロジー性を確認）。
- selectedIndex=0 リセットは既存の全 pull 成功挙動に相乗りし重複させていない。

## テスト
- `git.test.ts` +4: 切替 pull で scrollTop=0 発火 / 通常 pull で不発火 / 入口 const の保持 / 失敗時不発火
- `pane-actions-factory.dom.test.ts` 新規: URL query クリアの発火（切替）/不発火（テーマ・同名）/ queue 経路で repoChangePending 保持 / token queue で不発火 / Q1 history.state 保持（退行検知）
- 全 677 passed（回帰なし）、svelte-check 0 errors

## docs
`docs/development/sync/push-pull.md` の図2・ケース#19 を現行挙動（URLクリア・スクロール残骸リセット・queue 経路）に追従。

## 完了条件（実機サインオフ）
dev サーバで ①同名ノートを持つ repo 間の切替で home に収束するか ②一覧をスクロールした後の切替でスクロールが先頭に戻るか を目視。