### PR TITLE
test: 同期層の並行取得ヘルパーをcharacterizationテストで固定 (#231)

### DIFF
--- a/src/lib/api/github/__tests__/fetch-mock.ts
+++ b/src/lib/api/github/__tests__/fetch-mock.ts
@@ -29,6 +29,40 @@ export interface MockResponseSpec {
   text?: string
   /** レスポンスヘッダ（rate-limit ヘッダ等） */
   headers?: Record<string, string>
+  /**
+   * 応答を遅延させる（並列度の characterization 用・#231）。
+   * gate を渡すとその Promise が resolve するまで fetch は pending のまま
+   * （＝runWithConcurrency のスロットを掴んだまま）になる。
+   * 何も指定しなければ従来どおり即時 resolve（後方互換）。
+   */
+  gate?: Promise<unknown>
+  /** 応答を delay ミリ秒だけ遅延させる（gate と併用可） */
+  delay?: number
+}
+
+/** 手動 resolve できる Promise（deferred）。並列 in-flight を段階的に開放する用。 */
+export interface Deferred<T = void> {
+  promise: Promise<T>
+  resolve: (value?: T) => void
+  reject: (reason?: unknown) => void
+}
+
+export function createDeferred<T = void>(): Deferred<T> {
+  let resolve!: (value?: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res as (value?: T) => void
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+/** 特定の method + matcher にマッチする fetch の in-flight 数を追跡するトラッカ。 */
+export interface InFlightTracker {
+  /** 現在 pending 中の件数 */
+  readonly current: number
+  /** 観測された同時 in-flight の最大値 */
+  readonly max: number
 }
 
 export type UrlMatcher = string | RegExp | ((url: string) => boolean)
@@ -90,11 +124,22 @@ export interface FetchMock {
   assertDrained: () => void
   /** 未消費キューの件数（assertDrained の非例外版） */
   pendingCount: () => number
+  /** method + matcher にマッチする fetch の in-flight 数を追跡開始する。
+   *  gate/delay で応答を遅延させたとき、同時 in-flight のピークを観測できる。 */
+  track: (method: string, matcher: UrlMatcher) => InFlightTracker
+}
+
+interface TrackerState {
+  method: string
+  matcher: UrlMatcher
+  current: number
+  max: number
 }
 
 export function createFetchMock(): FetchMock {
   const queue: QueuedResponse[] = []
   const calls: RecordedCall[] = []
+  const trackers: TrackerState[] = []
 
   const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url = typeof input === 'string' ? input : input.toString()
@@ -145,7 +190,26 @@ export function createFetchMock(): FetchMock {
       )
     }
     const [matched] = queue.splice(idx, 1)
-    return specToResponse(matched.spec)
+
+    // in-flight 追跡: リクエスト受理〜応答 resolve までを bracket する。
+    // gate/delay で応答が pending の間はスロットを掴んだままなので、
+    // runWithConcurrency の同時実行数がここで観測できる。
+    const matchedTrackers = trackers.filter(
+      (t) => t.method.toUpperCase() === method && urlMatches(t.matcher, url)
+    )
+    for (const t of matchedTrackers) {
+      t.current++
+      if (t.current > t.max) t.max = t.current
+    }
+    try {
+      if (matched.spec.gate) await matched.spec.gate
+      if (matched.spec.delay) {
+        await new Promise((r) => setTimeout(r, matched.spec.delay))
+      }
+      return specToResponse(matched.spec)
+    } finally {
+      for (const t of matchedTrackers) t.current--
+    }
   })
 
   const mock: FetchMock = {
@@ -165,6 +229,18 @@ export function createFetchMock(): FetchMock {
     },
     pendingCount() {
       return queue.length
+    },
+    track(method, matcher) {
+      const state: TrackerState = { method, matcher, current: 0, max: 0 }
+      trackers.push(state)
+      return {
+        get current() {
+          return state.current
+        },
+        get max() {
+          return state.max
+        },
+      }
     },
     assertDrained() {
       if (queue.length > 0) {

--- a/src/lib/api/github/__tests__/github-concurrency.characterization.test.ts
+++ b/src/lib/api/github/__tests__/github-concurrency.characterization.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Characterization テスト（#231）— runWithConcurrency（module-private ヘルパ）
+ *
+ * runWithConcurrency は export されていないので、これを唯一使う public 関数
+ * pullFromGitHub / pullArchive の「リーフ content 並列取得」経由で外から pin する。
+ *
+ * 外からの観測方法（private ヘルパの契約を public 経由で捉える）:
+ *   - リーフ content fetch の識別子 = method GET かつ URL に `/contents/` を含む
+ *     （Accept: application/vnd.github.raw も付くが、metadata は /git/blobs/ 経由なので
+ *      `/contents/` だけで完全に分離できる）。
+ *   - fetch-mock の gate（deferred）で content 応答を pending のまま留め、
+ *     mock.track() で同時 in-flight のピークを観測する。応答が pending の間は
+ *     runWithConcurrency のワーカースロットを掴んだままなので、ここに並列度が現れる。
+ *
+ * すべて現状挙動をそのまま固定する（quirky でも修正しない）。
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+
+import { createFetchMock, createDeferred, makeSettings, type FetchMock } from './fetch-mock'
+
+// github.ts はバレル経由で stores → localStorage に触れるため、他 Wave と同じく
+// localStorage をスタブしてから動的 import する。
+const storageBacking = new Map<string, string>()
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => storageBacking.get(k) ?? null,
+  setItem: (k: string, v: string) => void storageBacking.set(k, v),
+  removeItem: (k: string) => void storageBacking.delete(k),
+  clear: () => storageBacking.clear(),
+  key: (i: number) => Array.from(storageBacking.keys())[i] ?? null,
+  get length() {
+    return storageBacking.size
+  },
+}
+
+const { pullFromGitHub, pullArchive } = await import('../../github')
+
+const REPO = 'https://api.github.com/repos/owner/repo'
+const NOTES = '.agasteer/notes'
+const ARCHIVE = '.agasteer/archive'
+
+// runWithConcurrency に渡る CONTENT_FETCH_CONCURRENCY（本番定数）は 10。
+const LIMIT = 10
+
+let mock: FetchMock
+
+beforeEach(() => {
+  mock = createFetchMock()
+  vi.stubGlobal('fetch', mock.fn)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+/** repo -> ref -> tree（1〜3 段）を即時応答で仕込む（pull 用） */
+function stagePullRepoRefTree(leafPaths: string[]) {
+  mock.on('GET', REPO, { json: { default_branch: 'main' } })
+  mock.on('GET', '/git/ref/heads/main', { json: { object: { sha: 'c' } } })
+  mock.on('GET', '/git/trees/main?recursive=1', {
+    json: {
+      truncated: false,
+      tree: leafPaths.map((p, i) => ({ path: `${NOTES}/${p}`, type: 'blob', sha: `sha-${i}` })),
+    },
+  })
+}
+
+/** repo -> tree（archive は ref を踏まない）を即時応答で仕込む */
+function stageArchiveRepoTree(leafPaths: string[]) {
+  mock.on('GET', REPO, { json: { default_branch: 'main' } })
+  mock.on('GET', '/git/trees/main?recursive=1', {
+    json: {
+      truncated: false,
+      tree: leafPaths.map((p, i) => ({ path: `${ARCHIVE}/${p}`, type: 'blob', sha: `asha-${i}` })),
+    },
+  })
+}
+
+/** content fetch = GET かつ URL に /contents/ を含む */
+const isContent = (url: string) => url.includes('/contents/')
+
+/** 全 pending microtask を吐き出す（macrotask 1 tick） */
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+// ============================================================
+// (a) 同時 in-flight <= limit(10)
+// ============================================================
+describe('runWithConcurrency: caps concurrent leaf content fetches at the limit', () => {
+  it('never runs more than 10 content fetches in flight even with 15 staged leaves', async () => {
+    const N = 15
+    const paths = Array.from({ length: N }, (_, i) => `Note/L${String(i).padStart(2, '0')}.md`)
+    stagePullRepoRefTree(paths)
+
+    // 各リーフ content 応答を gate（deferred）で pending 固定 → スロットを掴んだままにする。
+    const gates = paths.map(() => createDeferred())
+    paths.forEach((p, i) => {
+      mock.on('GET', `/contents/${NOTES}/${p}`, { text: `body-${i}`, gate: gates[i].promise })
+    })
+
+    const contentTracker = mock.track('GET', isContent)
+
+    // await せずに走らせる。gate 未 resolve の間は content fetch が pending。
+    const pending = pullFromGitHub(makeSettings())
+
+    // 先行ワーカーが立ち上がるのを待つ（repo/ref/tree は即時、content は gate で止まる）。
+    await vi.waitFor(() => expect(contentTracker.current).toBe(LIMIT))
+
+    // gate を一切 resolve していないので、11 本目は始まらない（＝先行 10 本が
+    // resolve するまで次は動かない）。少し待っても 10 で頭打ちのまま。
+    await flush()
+    expect(contentTracker.current).toBe(LIMIT)
+    expect(mock.callsMatching('GET', isContent)).toHaveLength(LIMIT)
+
+    // 先行 10 本を resolve → スロットが空き、残り 5 本が流れ込む。
+    gates.forEach((g) => g.resolve())
+    const res = await pending
+
+    expect(res.success).toBe(true)
+    // 全 15 本が最終的に取得され、
+    expect(res.leaves).toHaveLength(N)
+    // 同時 in-flight のピークは limit を超えない。
+    expect(contentTracker.max).toBeLessThanOrEqual(LIMIT)
+    expect(contentTracker.max).toBe(LIMIT)
+    expect(mock.callsMatching('GET', isContent)).toHaveLength(N)
+  })
+})
+
+// ============================================================
+// (c) items < limit: 立ち上がりが items 数で頭打ち
+// ============================================================
+describe('runWithConcurrency: does not spin up more workers than items', () => {
+  it('peaks in-flight at 3 (not 10) when only 3 leaves are staged', async () => {
+    const paths = ['N/A.md', 'N/B.md', 'N/C.md']
+    stagePullRepoRefTree(paths)
+    const gates = paths.map(() => createDeferred())
+    paths.forEach((p, i) => {
+      mock.on('GET', `/contents/${NOTES}/${p}`, { text: `b${i}`, gate: gates[i].promise })
+    })
+
+    const contentTracker = mock.track('GET', isContent)
+    const pending = pullFromGitHub(makeSettings())
+
+    // ワーカー数 = min(limit, items) = 3。3 本立ち上がったら頭打ち。
+    await vi.waitFor(() => expect(contentTracker.current).toBe(3))
+    await flush()
+    expect(contentTracker.current).toBe(3)
+
+    gates.forEach((g) => g.resolve())
+    const res = await pending
+    expect(res.success).toBe(true)
+    // limit(10) までは立ち上がらない。
+    expect(contentTracker.max).toBe(3)
+  })
+})
+
+// ============================================================
+// (e) 完了順の onLeaf 発火 vs 最終 leaves の再ソート
+// ============================================================
+describe('runWithConcurrency: onLeaf fires in completion order; final leaves re-sorted by order', () => {
+  it('fires onLeaf in resolution order (reverse) but returns leaves sorted ascending by order', async () => {
+    // tree 順（= 既定 order 昇順）で A(0) B(1) C(2) を仕込み、
+    // gate を逆順（C→B→A）に resolve して完了順を order 昇順とわざと食い違わせる。
+    const paths = ['N/A.md', 'N/B.md', 'N/C.md']
+    stagePullRepoRefTree(paths)
+    const gA = createDeferred()
+    const gB = createDeferred()
+    const gC = createDeferred()
+    mock.on('GET', `/contents/${NOTES}/N/A.md`, { text: 'a', gate: gA.promise })
+    mock.on('GET', `/contents/${NOTES}/N/B.md`, { text: 'b', gate: gB.promise })
+    mock.on('GET', `/contents/${NOTES}/N/C.md`, { text: 'c', gate: gC.promise })
+
+    const contentTracker = mock.track('GET', isContent)
+    const onLeafOrder: string[] = []
+    const onLeaf = vi.fn((leaf: any) => onLeafOrder.push(leaf.title))
+
+    const pending = pullFromGitHub(makeSettings(), { onLeaf })
+
+    // 3 本とも in-flight になってから逆順で開放する。
+    await vi.waitFor(() => expect(contentTracker.current).toBe(3))
+    gC.resolve()
+    await flush()
+    gB.resolve()
+    await flush()
+    gA.resolve()
+
+    const res = await pending
+    expect(res.success).toBe(true)
+
+    // onLeaf は完了順（C, B, A）で発火する。
+    expect(onLeafOrder).toEqual(['C', 'B', 'A'])
+    // 一方、最終 res.leaves は order 昇順に再ソートされ、onLeaf 発火順とは独立（A, B, C）。
+    expect(res.leaves.map((l) => l.title)).toEqual(['A', 'B', 'C'])
+  })
+})
+
+// ============================================================
+// 失敗リーフは onLeaf を発火しない（コールバック発火に絞った観点）
+// ============================================================
+describe('runWithConcurrency: failed content fetch does not fire onLeaf', () => {
+  it('fires onLeaf only for the successful leaves when one content fetch fails', async () => {
+    const paths = ['N/Ok1.md', 'N/Bad.md', 'N/Ok2.md']
+    stagePullRepoRefTree(paths)
+    mock.on('GET', `/contents/${NOTES}/N/Ok1.md`, { text: 'ok1' })
+    mock.on('GET', `/contents/${NOTES}/N/Bad.md`, { status: 500, json: {} }) // 失敗
+    mock.on('GET', `/contents/${NOTES}/N/Ok2.md`, { text: 'ok2' })
+
+    const onLeafTitles: string[] = []
+    const onLeaf = vi.fn((leaf: any) => onLeafTitles.push(leaf.title))
+
+    // 部分失敗なので pull 全体は E-2008（既存テストで固定済み）。ここは onLeaf 発火だけ観る。
+    const res = await pullFromGitHub(makeSettings(), { onLeaf })
+    expect(res.success).toBe(false)
+    expect(res.errorCode).toBe('E-2008')
+
+    // onLeaf は成功した 2 本だけ発火し、失敗リーフでは発火しない。
+    expect(onLeaf).toHaveBeenCalledTimes(2)
+    expect([...onLeafTitles].sort()).toEqual(['Ok1', 'Ok2'])
+  })
+})
+
+// ============================================================
+// pullArchive 版（pull と分岐する onLeafFetched コールバックだけ確認）
+// ============================================================
+describe('runWithConcurrency via pullArchive', () => {
+  it('caps archive content fetches at the limit and fires onLeafFetched per success', async () => {
+    const N = 12
+    const paths = Array.from({ length: N }, (_, i) => `Old/L${String(i).padStart(2, '0')}.md`)
+    stageArchiveRepoTree(paths)
+    const gates = paths.map(() => createDeferred())
+    paths.forEach((p, i) => {
+      mock.on('GET', `/contents/${ARCHIVE}/${p}`, { text: `arch-${i}`, gate: gates[i].promise })
+    })
+
+    const contentTracker = mock.track('GET', isContent)
+    const onLeafFetched = vi.fn()
+    const pending = pullArchive(makeSettings(), { onLeafFetched })
+
+    // pull と同じ limit(10) で頭打ち。
+    await vi.waitFor(() => expect(contentTracker.current).toBe(LIMIT))
+    await flush()
+    expect(contentTracker.current).toBe(LIMIT)
+
+    gates.forEach((g) => g.resolve())
+    const res = await pending
+
+    expect(res.success).toBe(true)
+    expect(contentTracker.max).toBe(LIMIT)
+    // archive は onLeafFetched を成功リーフ 1 本ごとに発火する（pull の onLeaf に対応）。
+    expect(onLeafFetched).toHaveBeenCalledTimes(N)
+  })
+})

--- a/src/lib/api/github/__tests__/github-concurrency.characterization.test.ts
+++ b/src/lib/api/github/__tests__/github-concurrency.characterization.test.ts
@@ -121,8 +121,7 @@ describe('runWithConcurrency: caps concurrent leaf content fetches at the limit'
     expect(res.success).toBe(true)
     // 全 15 本が最終的に取得され、
     expect(res.leaves).toHaveLength(N)
-    // 同時 in-flight のピークは limit を超えない。
-    expect(contentTracker.max).toBeLessThanOrEqual(LIMIT)
+    // 同時 in-flight のピークは limit ちょうどに到達し、超えない。
     expect(contentTracker.max).toBe(LIMIT)
     expect(mock.callsMatching('GET', isContent)).toHaveLength(N)
   })

--- a/src/lib/api/github/__tests__/github-status.characterization.test.ts
+++ b/src/lib/api/github/__tests__/github-status.characterization.test.ts
@@ -73,6 +73,11 @@ describe('fetchCurrentSha', () => {
     // キャッシュバスター ?t= が付く
     expect(call!.url).toMatch(/\/repos\/owner\/repo\/contents\/foo\/bar\.md\?t=\d+/)
     expect(call!.headers.Authorization).toBe('Bearer test-token')
+    // non-raw 経路（fetchGitHubContents を raw オプション無しで呼ぶ）なので
+    // Accept ヘッダは付かない（undefined）。pull のリーフ取得（raw）との差を pin。
+    expect(call!.headers.Accept).toBeUndefined()
+    // キャッシュバスター ?t= を必ず含む（現状挙動）。
+    expect(call!.url).toContain('?t=')
   })
 
   it('returns null when the file does not exist (non-ok response)', async () => {


### PR DESCRIPTION
## 関連 Issue
closes #231

## 背景
github.ts（2078行の god-file）の同期層を #226 で責務別分割する前に、現状の振る舞いを golden master として固定する安全網。既存の characterization テスト（push/pull/status/rate-limit）は広範にカバー済みで、本 PR は**残る module-private ヘルパー2つの未カバー挙動だけ**を埋める。

## 変更内容
**本番コード（src/lib/api/github.ts）は一切変更していない（characterization は観測のみ）。**

- **新規** `github-concurrency.characterization.test.ts` — `runWithConcurrency` を public な pullFromGitHub / pullArchive のリーフ並列取得経由で pin:
  - 同時 in-flight ≤ limit(10)（15本ステージ・11本目は先行10本 resolve まで開始しない）
  - items<limit(3本)では in-flight が items 数で頭打ち
  - onLeaf は完了順に発火・最終 res.leaves は order 昇順に再ソート（現状の食い違いをそのまま固定）
  - 失敗リーフ（content fetch 500）では onLeaf を発火しない
  - pullArchive 版は分岐点の onLeafFetched のみ最小限
- **追記** `github-status.characterization.test.ts` — fetchCurrentSha（非raw経路）が Accept ヘッダを付けない + `?t=` cache-buster を pin
- **拡張** `fetch-mock.ts` — gate(deferred)/delay と in-flight tracker を追加（テスト基盤のみ・既存挙動は即時 resolve のまま後方互換）

## テスト
- `npx vitest run src/lib/api/github`: 8 files / 150 passed
- `npm test`（全体）: 47 files / 706 passed, 3 skipped
- svelte-check: 0 errors / prettier: clean
- concurrency テストは gate/deferred で決定論的（5連続実行フレークなし）