### PR TITLE
refactor: 副作用層 http.ts を github.ts から分離 (#226 Phase 2)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -171,11 +171,12 @@ agasteer/
 │   │   ├── drag-drop.ts                 # ドラッグ&ドロップヘルパー
 │   │   ├── font.ts                      # カスタムフォント管理
 │   │   ├── github.ts                    # GitHub API統合（副作用層: push/pull/http）
-│   │   ├── github/                       # GitHub 純粋層（Phase 1で分離）
+│   │   ├── github/                       # GitHub 純粋層/低レベル副作用層（Phase 1-2で分離）
 │   │   │   ├── paths.ts                 # パス定数・パス構築（純粋）
 │   │   │   ├── encoding.ts              # Base64/UTF-8変換（純粋）
 │   │   │   ├── sha.ts                   # Git blob SHA計算（純粋）
-│   │   │   └── rate-limit.ts            # レート制限解析（純粋）
+│   │   │   ├── rate-limit.ts            # レート制限解析（純粋）
+│   │   │   └── http.ts                  # Contents API fetch/並列ワーカー/設定検証（副作用層・Phase 2）
 │   │   ├── media.ts                     # メディア同期層（副作用層: lazy作成/アップロード/キュー/キャッシュ）#242
 │   │   ├── media/                       # メディア純粋層（github/ の分割パターン踏襲）
 │   │   │   ├── base64.ts                # バイナリ安全な ArrayBuffer↔Base64（純粋）
@@ -340,7 +341,7 @@ agasteer/
 
 **GitHub同期:**
 
-- `github.ts`: GitHub API統合（ファイル保存、SHA取得、Git Tree API）。純粋層は `github/` 配下へ分離（Phase 1: paths/encoding/sha/rate-limit）。push/pull/http の副作用層は github.ts に残し、純粋関数を re-export して公開 API を維持
+- `github.ts`: GitHub API統合（ファイル保存、SHA取得、Git Tree API）。純粋層は `github/` 配下へ分離（Phase 1: paths/encoding/sha/rate-limit）。低レベル副作用ヘルパー（Contents API fetch/並列ワーカー/設定検証）は Phase 2 で `github/http.ts` へ純移動（非公開のまま github.ts が import）。push/pull の副作用層は github.ts に残し、純粋関数を re-export して公開 API を維持
 - `sync.ts`: Push/Pull処理の分離
 - `media.ts`: メディア同期層（#242）。別リポ `{owner}/{repo}-media` の lazy 作成・アップロード（pending キュー + online リトライ）・認証付き取得・LRU キャッシュ。`uploadMedia` は enqueue で即返し、実アップロードは背景の**グローバル直列チェーン**で流す（#247。同一リポへの並行 PUT が 409 になるのを直列化で回避。戻り値 `uploadDone: Promise<boolean>`。チェーン経路の fetch はタイムアウト付きで head-of-line blocking を防ぐ #252）。Push/Pull フロー・WorldType とは独立。純粋層は `media/` 配下（base64/naming/validation/lru）
 

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -33,6 +33,7 @@ import {
 import { parseRateLimitResponse, type RateLimitInfo } from './github/rate-limit'
 import { calculateGitBlobSha } from './github/sha'
 import { encodeContent, decodeBase64ToString } from './github/encoding'
+import { fetchGitHubContents, runWithConcurrency, validateGitHubSettings } from './github/http'
 import {
   PUSH_STAGE_REFS,
   PUSH_STAGE_BASE_TREE,
@@ -138,63 +139,6 @@ export interface PullOptions {
 
 // コンテンツ取得を並列化する際の上限（HTTP/2では同時接続数制限が緩和されている）
 const CONTENT_FETCH_CONCURRENCY = 10
-
-async function runWithConcurrency<T, R>(
-  items: T[],
-  limit: number,
-  worker: (item: T, index: number) => Promise<R | null>
-): Promise<R[]> {
-  const results: R[] = []
-  let index = 0
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (true) {
-      const currentIndex = index++
-      if (currentIndex >= items.length) break
-      const item = items[currentIndex]
-      const result = await worker(item, currentIndex)
-      if (result !== null) {
-        results.push(result)
-      }
-    }
-  })
-  await Promise.all(workers)
-  return results
-}
-/**
- * GitHub設定を検証
- * @returns valid: true または valid: false と i18nキー
- */
-function validateGitHubSettings(settings: Settings): { valid: boolean; errorKey?: string } {
-  if (!settings.token) {
-    return { valid: false, errorKey: 'github.tokenNotSet' }
-  }
-  if (!settings.repoName || !settings.repoName.includes('/')) {
-    return { valid: false, errorKey: 'github.invalidRepoName' }
-  }
-  return { valid: true }
-}
-
-/**
- * GitHub Contents APIを呼ぶヘルパー関数（キャッシュバスター付き）
- */
-async function fetchGitHubContents(
-  path: string,
-  repoName: string,
-  token: string,
-  options?: { raw?: boolean }
-) {
-  const url = `https://api.github.com/repos/${repoName}/contents/${path}?t=${Date.now()}`
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
-  }
-  // RawモードはBase64デコードを省きレスポンスサイズを抑える
-  if (options?.raw) {
-    headers.Accept = 'application/vnd.github.raw'
-  }
-  return fetch(url, {
-    headers,
-  })
-}
 
 /**
  * 既存ファイルのSHAを取得

--- a/src/lib/api/github/http.test.ts
+++ b/src/lib/api/github/http.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+
+import { fetchGitHubContents, runWithConcurrency, validateGitHubSettings } from './http'
+import type { Settings } from '../../types'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('fetchGitHubContents', () => {
+  function mockFetch() {
+    const spy = vi.fn(
+      async (_url: string, _init?: RequestInit) => new Response(null, { status: 200 })
+    )
+    vi.stubGlobal('fetch', spy)
+    return spy
+  }
+
+  it('builds a Contents API URL with a cache-buster query param', async () => {
+    const fetchSpy = mockFetch()
+    await fetchGitHubContents('notes/foo.md', 'owner/repo', 'tok')
+    const url = fetchSpy.mock.calls[0][0] as string
+    expect(url).toContain('https://api.github.com/repos/owner/repo/contents/notes/foo.md')
+    expect(url).toMatch(/\?t=\d+/)
+  })
+
+  it('sends an Authorization: Bearer header', async () => {
+    const fetchSpy = mockFetch()
+    await fetchGitHubContents('p', 'owner/repo', 'secret-token')
+    const init = fetchSpy.mock.calls[0][1] as RequestInit
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer secret-token')
+  })
+
+  it('sets the raw Accept header only when options.raw is true', async () => {
+    const fetchSpy = mockFetch()
+    await fetchGitHubContents('p', 'owner/repo', 'tok', { raw: true })
+    const headers = fetchSpy.mock.calls[0][1]!.headers as Record<string, string>
+    expect(headers.Accept).toBe('application/vnd.github.raw')
+  })
+
+  it('omits the Accept header when raw is not requested', async () => {
+    const fetchSpy = mockFetch()
+    await fetchGitHubContents('p', 'owner/repo', 'tok')
+    const headers = fetchSpy.mock.calls[0][1]!.headers as Record<string, string>
+    expect(headers.Accept).toBeUndefined()
+  })
+})
+
+describe('runWithConcurrency', () => {
+  it('returns an empty array for empty input', async () => {
+    const worker = vi.fn(async (n: number) => n)
+    expect(await runWithConcurrency([], 5, worker)).toEqual([])
+    expect(worker).not.toHaveBeenCalled()
+  })
+
+  it('excludes items whose worker returns null', async () => {
+    const results = await runWithConcurrency([1, 2, 3, 4], 2, async (n) => (n % 2 === 0 ? n : null))
+    expect(results.sort((a, b) => a - b)).toEqual([2, 4])
+  })
+
+  it('spawns min(limit, items.length) workers', async () => {
+    let active = 0
+    let peak = 0
+    const resolvers: Array<() => void> = []
+    const promise = runWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => {
+      active++
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => resolvers.push(resolve))
+      active--
+      return n
+    })
+    // Let the initial workers start.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(peak).toBe(2)
+    // Drain all pending workers.
+    while (resolvers.length > 0) {
+      resolvers.shift()!()
+      await Promise.resolve()
+      await Promise.resolve()
+    }
+    await promise
+  })
+
+  it('caps worker count at items.length when limit exceeds it', async () => {
+    let peak = 0
+    let active = 0
+    await runWithConcurrency([1, 2], 10, async (n) => {
+      active++
+      peak = Math.max(peak, active)
+      await Promise.resolve()
+      active--
+      return n
+    })
+    expect(peak).toBeLessThanOrEqual(2)
+  })
+
+  it('pushes results in completion order, not input order', async () => {
+    const gates: Record<number, () => void> = {}
+    const promise = runWithConcurrency([1, 2], 2, async (n) => {
+      await new Promise<void>((resolve) => {
+        gates[n] = resolve
+      })
+      return n
+    })
+    await Promise.resolve()
+    // Complete item 2 before item 1.
+    gates[2]()
+    await Promise.resolve()
+    gates[1]()
+    const results = await promise
+    expect(results).toEqual([2, 1])
+  })
+})
+
+describe('validateGitHubSettings', () => {
+  function makeSettings(overrides: Partial<Settings>): Settings {
+    return { token: 'tok', repoName: 'owner/repo', ...overrides } as Settings
+  }
+
+  it('returns tokenNotSet when the token is empty', () => {
+    expect(validateGitHubSettings(makeSettings({ token: '' }))).toEqual({
+      valid: false,
+      errorKey: 'github.tokenNotSet',
+    })
+  })
+
+  it('returns invalidRepoName when repoName has no slash', () => {
+    expect(validateGitHubSettings(makeSettings({ repoName: 'noslash' }))).toEqual({
+      valid: false,
+      errorKey: 'github.invalidRepoName',
+    })
+  })
+
+  it('returns valid for a well-formed settings object', () => {
+    expect(validateGitHubSettings(makeSettings({}))).toEqual({ valid: true })
+  })
+})

--- a/src/lib/api/github/http.ts
+++ b/src/lib/api/github/http.ts
@@ -1,0 +1,70 @@
+/**
+ * GitHub API 低レベル HTTP ヘルパー（副作用層）
+ *
+ * Contents API の fetch・並列ワーカー・設定検証をまとめる。
+ * github.ts から純移動（Phase 2）。振る舞いは不変。
+ */
+
+import type { Settings } from '../../types'
+
+/**
+ * 複数アイテムを並列上限付きで処理する
+ * worker が null を返した要素は結果から除外する
+ */
+export async function runWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R | null>
+): Promise<R[]> {
+  const results: R[] = []
+  let index = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const currentIndex = index++
+      if (currentIndex >= items.length) break
+      const item = items[currentIndex]
+      const result = await worker(item, currentIndex)
+      if (result !== null) {
+        results.push(result)
+      }
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
+/**
+ * GitHub設定を検証
+ * @returns valid: true または valid: false と i18nキー
+ */
+export function validateGitHubSettings(settings: Settings): { valid: boolean; errorKey?: string } {
+  if (!settings.token) {
+    return { valid: false, errorKey: 'github.tokenNotSet' }
+  }
+  if (!settings.repoName || !settings.repoName.includes('/')) {
+    return { valid: false, errorKey: 'github.invalidRepoName' }
+  }
+  return { valid: true }
+}
+
+/**
+ * GitHub Contents APIを呼ぶヘルパー関数（キャッシュバスター付き）
+ */
+export async function fetchGitHubContents(
+  path: string,
+  repoName: string,
+  token: string,
+  options?: { raw?: boolean }
+) {
+  const url = `https://api.github.com/repos/${repoName}/contents/${path}?t=${Date.now()}`
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  }
+  // RawモードはBase64デコードを省きレスポンスサイズを抑える
+  if (options?.raw) {
+    headers.Accept = 'application/vnd.github.raw'
+  }
+  return fetch(url, {
+    headers,
+  })
+}


### PR DESCRIPTION
## 関連 Issue
Refs #226（Phase 2 のみ。Phase 3 の巨大関数抽出・actions/git.ts・ui.svelte.ts は別 PR）

## 背景
github.ts（2078行の god-file）分割の Phase 2。Phase 1（paths/rate-limit/sha/encoding の純粋層分離）は完了済み、#231 で同期層 characterization 安全網も整備済み。本 PR はその安全網に守られた**振る舞い不変・公開 API 不変の純移動**。

## 変更内容
- **新規** `github/http.ts` — github.ts の module-private ヘルパー3つをロジック不変で移動・export:
  - `fetchGitHubContents`（Contents API・cache-buster/Bearer/raw Accept）
  - `runWithConcurrency`（並列取得ドライバ）
  - `validateGitHubSettings`（設定検証）
- **変更** `github.ts` — 上記を http.ts から import。3つは元々非公開のため公開 API は完全不変（`export {}` に不追加）。**2078 → 2022 行**。
- **新規** `github/http.test.ts` — 切り出した3関数の直接単体テスト12件（Phase 1 各モジュールと同流儀）。
- **変更** `docs/development/architecture.md` — モジュール構成に http.ts を追記。

## 振る舞い不変の根拠
#231 で整備した public 経由の characterization テスト（github-concurrency / github-status / github-pull / github-push）が**移動後も全緑**。これが「実装を別モジュールへ動かしても外形挙動が変わっていない」ことの回帰検知になっている。

## テスト
- `npx vitest run src/lib/api/github`: 9 files / 162 passed
- `npm test`（全体）: 718 passed / 3 skipped
- svelte-check: 0 errors / prettier: clean