### PR TITLE
refactor: Push トーストのペーシング状態機械を push-toast.svelte.ts へ分離 (#226)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -213,7 +213,8 @@ agasteer/
 │   │   ├── theme.ts                     # テーマ管理
 │   │   ├── types.ts                     # TypeScript型定義
 │   │   └── ui/
-│   │       └── ui.svelte.ts             # トースト状態管理
+│   │       ├── ui.svelte.ts             # Pull トースト・モーダル状態管理（push は re-export）
+│   │       └── push-toast.svelte.ts     # Push トーストのペーシング状態機械（#238）
 │   ├── app.css                          # グローバルスタイル + テーマ定義
 │   ├── app.d.ts                         # TypeScript型宣言
 │   ├── App.svelte                       # ルートコンポーネント
@@ -360,7 +361,8 @@ agasteer/
 
 - `theme.ts`: テーマ適用ロジック
 - `routing.ts`: URLルーティング（パスベース、プレビュー対応）
-- `ui/ui.svelte.ts`: トースト状態管理
+- `ui/ui.svelte.ts`: Pull トースト・モーダル状態管理（Push トーストは `push-toast.svelte.ts` を同名 re-export し公開 API 不変）
+- `ui/push-toast.svelte.ts`: Push トーストのペーシング状態機械（カウントダウン・単調減少ガード・MIN_HOLD キュー、#238）
 - `font.ts`: カスタムフォント管理（IndexedDB保存、動的@font-face登録）
 
 **Svelteアクション（actions/）:**

--- a/src/lib/ui/push-toast.svelte.ts
+++ b/src/lib/ui/push-toast.svelte.ts
@@ -1,0 +1,192 @@
+import { clampMonotonicCountdown } from '../sync/push-stages'
+import type { ToastState } from './ui.svelte'
+
+/**
+ * Pushトーストの状態
+ */
+let _pushToastState = $state<ToastState>({
+  message: '',
+  variant: '',
+})
+export const pushToastState = {
+  get value() {
+    return _pushToastState
+  },
+  set value(v: ToastState) {
+    _pushToastState = v
+  },
+}
+
+/**
+ * Push トーストのカウントダウン（残りステージ数、#238）
+ *
+ * sticky Push トースト表示中に FF 風カウントダウンとして 2 行目に表示する。
+ * null = 非表示。setPushToastCountdown は単調減少ガード付きで、リトライ・
+ * 救済経路で内部的にステージが巻き戻っても表示上の数字は絶対に増やさない。
+ */
+let _pushToastCountdown = $state<number | null>(null)
+export const pushToastCountdown = {
+  get value() {
+    return _pushToastCountdown
+  },
+}
+
+/**
+ * カウントダウンの最低表示時間（ペーシング、#238 実機フィードバック）。
+ *
+ * 実ステージの所要は偏っている（3=本文アップロードが支配的、2/1 は軽い API で
+ * 一瞬）ため、通知をそのまま反映すると終盤の数字が駆け抜けて読めない。
+ * 表示中の数字は最低この時間保持し、次の値はキューに積んで順に表示する。
+ */
+export const PUSH_COUNTDOWN_MIN_HOLD_MS = 400
+
+/** 表示待ちの残りステージ数キュー（単調減少ガード通過済みの値だけが入る） */
+let countdownQueue: number[] = []
+/** 表示中の数字の最低保持タイマー。非 null の間は次の値を表示しない */
+let countdownHoldTimer: ReturnType<typeof setTimeout> | null = null
+/**
+ * キュー消化待ちの Push 完了トースト（success のみ・showPushCompletionToast 専用）。
+ * drain 完了時、または割り込んだ汎用トーストの2秒消滅時に必ず表示される
+ */
+let pendingSuccessToast: ToastState | null = null
+
+/** カウントダウンがまだ消化中（数字を保持中、またはキューに次の値がある）か */
+function isCountdownDraining(): boolean {
+  return countdownHoldTimer !== null || countdownQueue.length > 0
+}
+
+/** カウントダウンのキュー・保持タイマーだけを破棄する（遅延中の完了トーストは残す） */
+function discardCountdownQueue() {
+  countdownQueue = []
+  if (countdownHoldTimer !== null) {
+    clearTimeout(countdownHoldTimer)
+    countdownHoldTimer = null
+  }
+}
+
+/** ペーシング状態（キュー・保持タイマー・遅延中の完了トースト）を全破棄する */
+function resetCountdownPacing() {
+  discardCountdownQueue()
+  pendingSuccessToast = null
+}
+
+/**
+ * キューの先頭を表示して MIN_HOLD の保持に入る。保持中なら何もしない
+ * （保持タイマー満了時に再帰的に呼ばれて次を消化する）。
+ * キューが掃けたら、遅延していた成功トーストを表示する。
+ */
+function drainCountdownQueue() {
+  if (countdownHoldTimer !== null) return
+  const next = countdownQueue.shift()
+  if (next === undefined) {
+    // キューが掃けた（最後の数字も MIN_HOLD 表示済み）
+    const pending = pendingSuccessToast
+    if (pending !== null) {
+      pendingSuccessToast = null
+      displayPushToast(pending.message, pending.variant)
+    }
+    return
+  }
+  _pushToastCountdown = next
+  countdownHoldTimer = setTimeout(() => {
+    countdownHoldTimer = null
+    drainCountdownQueue()
+  }, PUSH_COUNTDOWN_MIN_HOLD_MS)
+}
+
+/**
+ * Pushトーストを表示（push スロット共用の汎用入口）
+ *
+ * crud / move / share / io / OCR 等、Push 完了以外の通知もここを通るため、
+ * variant を問わず常に即時表示する（ペーシングによる遅延はかけない）。
+ * カウントダウン消化中に割り込んだ場合はキュー・保持タイマーを破棄する
+ * （無関係トーストの下に数字が湧き出すのを防ぐ）が、遅延中の Push 完了
+ * トースト（pending）は破棄せず、このトーストの2秒消滅時に表示される。
+ */
+export function showPushToast(message: string, variant: 'success' | 'error' | '' = '') {
+  discardCountdownQueue()
+  displayPushToast(message, variant)
+}
+
+/**
+ * Push 完了トーストを表示する（`actions/git.ts` の Push 完了経路専用、#238）。
+ *
+ * ペーシング対象はこの入口だけ: カウントダウンの消化中（数字を保持中または
+ * キューあり）に success で呼ばれた場合は、最後の数字が MIN_HOLD 表示される
+ * まで差し替えを遅延する（最悪ケース: キュー4件 + 保持中で +2秒弱の安全側
+ * 遅延）。遅延中の完了トーストは drain 完了時、または割り込んだ汎用トースト
+ * の2秒消滅時に必ず表示される。error（タイムアウト・失敗）は待たせられない
+ * のでキュー・タイマー・pending を破棄して即時表示する。
+ */
+export function showPushCompletionToast(message: string, variant: 'success' | 'error' = 'success') {
+  if (variant === 'success' && isCountdownDraining()) {
+    // drain 完了時（drainCountdownQueue）または汎用トーストの2秒消滅時に
+    // 表示される。完了トースト同士は後勝ち（最新の Push の結果が残る）
+    pendingSuccessToast = { message, variant }
+    return
+  }
+  resetCountdownPacing()
+  displayPushToast(message, variant)
+}
+
+/** Push トーストを実際に差し替えて2秒の自動消滅タイマーを張る（内部用） */
+function displayPushToast(message: string, variant: 'success' | 'error' | '') {
+  pushToastState.value = { message, variant }
+  // 完了/エラートーストへの差し替え時点でカウントダウンは役目を終える
+  _pushToastCountdown = null
+  setTimeout(() => {
+    // 自分が出したトーストがまだ表示中のときだけ触る。
+    // 後から別のトースト（sticky 含む）に差し替わっていたら触らない（後勝ち）。
+    if (pushToastState.value.message !== message) return
+    // 遅延中の Push 完了トーストがあれば、消す代わりにそれを表示する
+    // （pending の完了トーストは必ず最終的に表示されることの保証）
+    const pending = pendingSuccessToast
+    if (pending !== null) {
+      pendingSuccessToast = null
+      displayPushToast(pending.message, pending.variant)
+      return
+    }
+    pushToastState.value = { message: '', variant: '' }
+    // トーストを空にするならカウントダウンも残さない（不変条件を局所で保証）
+    _pushToastCountdown = null
+  }, 2000)
+}
+
+/**
+ * Push の sticky トーストを表示する（自動消滅しない）。
+ * isPushingBackground の間だけ出し、完了トースト（showPushCompletionToast）や
+ * 他操作のトースト（showPushToast）、clearPushToast で差し替わる（後勝ち）。
+ */
+export function showStickyPushToast(message: string) {
+  pushToastState.value = { message, variant: '' }
+  // 新しい Push の開始（トースト再表示）なので、カウントダウンとペーシング
+  // （キュー・保持タイマー・遅延中の成功トースト）を全リセットする。
+  // 単調減少ガードのリセットが許されるのはこのタイミングだけ（#238）
+  resetCountdownPacing()
+  _pushToastCountdown = null
+}
+
+/**
+ * Push トーストのカウントダウン（残りステージ数）を更新する（#238）。
+ *
+ * 単調減少ガードはキュー投入時に「表示中の値とキュー末尾のうち最小」に対して
+ * 適用する: 増加値・重複値は捨てる。リトライ・救済経路で内部的にステージが
+ * 巻き戻っても数字は増えない。通過した値は即時反映ではなくペーシングキューに
+ * 積まれ、各数字が最低 MIN_HOLD 表示されてから順に出る。
+ */
+export function setPushToastCountdown(remainingStages: number) {
+  const floor =
+    countdownQueue.length > 0 ? countdownQueue[countdownQueue.length - 1] : _pushToastCountdown
+  if (clampMonotonicCountdown(floor, remainingStages) === floor) return
+  countdownQueue.push(remainingStages)
+  drainCountdownQueue()
+}
+
+/**
+ * Pushトーストを即座に消す
+ */
+export function clearPushToast() {
+  pushToastState.value = { message: '', variant: '' }
+  resetCountdownPacing()
+  _pushToastCountdown = null
+}

--- a/src/lib/ui/ui.svelte.ts
+++ b/src/lib/ui/ui.svelte.ts
@@ -1,5 +1,4 @@
 import { tick } from 'svelte'
-import { clampMonotonicCountdown } from '../sync/push-stages'
 
 /**
  * トースト通知の状態
@@ -41,97 +40,19 @@ export interface ModalState {
 }
 
 /**
- * Pushトーストの状態
+ * Push トーストのペーシング状態機械（#226 で push-toast.svelte.ts へ純移動）。
+ * 公開 API を不変に保つため同名で re-export する。
  */
-let _pushToastState = $state<ToastState>({
-  message: '',
-  variant: '',
-})
-export const pushToastState = {
-  get value() {
-    return _pushToastState
-  },
-  set value(v: ToastState) {
-    _pushToastState = v
-  },
-}
-
-/**
- * Push トーストのカウントダウン（残りステージ数、#238）
- *
- * sticky Push トースト表示中に FF 風カウントダウンとして 2 行目に表示する。
- * null = 非表示。setPushToastCountdown は単調減少ガード付きで、リトライ・
- * 救済経路で内部的にステージが巻き戻っても表示上の数字は絶対に増やさない。
- */
-let _pushToastCountdown = $state<number | null>(null)
-export const pushToastCountdown = {
-  get value() {
-    return _pushToastCountdown
-  },
-}
-
-/**
- * カウントダウンの最低表示時間（ペーシング、#238 実機フィードバック）。
- *
- * 実ステージの所要は偏っている（3=本文アップロードが支配的、2/1 は軽い API で
- * 一瞬）ため、通知をそのまま反映すると終盤の数字が駆け抜けて読めない。
- * 表示中の数字は最低この時間保持し、次の値はキューに積んで順に表示する。
- */
-export const PUSH_COUNTDOWN_MIN_HOLD_MS = 400
-
-/** 表示待ちの残りステージ数キュー（単調減少ガード通過済みの値だけが入る） */
-let countdownQueue: number[] = []
-/** 表示中の数字の最低保持タイマー。非 null の間は次の値を表示しない */
-let countdownHoldTimer: ReturnType<typeof setTimeout> | null = null
-/**
- * キュー消化待ちの Push 完了トースト（success のみ・showPushCompletionToast 専用）。
- * drain 完了時、または割り込んだ汎用トーストの2秒消滅時に必ず表示される
- */
-let pendingSuccessToast: ToastState | null = null
-
-/** カウントダウンがまだ消化中（数字を保持中、またはキューに次の値がある）か */
-function isCountdownDraining(): boolean {
-  return countdownHoldTimer !== null || countdownQueue.length > 0
-}
-
-/** カウントダウンのキュー・保持タイマーだけを破棄する（遅延中の完了トーストは残す） */
-function discardCountdownQueue() {
-  countdownQueue = []
-  if (countdownHoldTimer !== null) {
-    clearTimeout(countdownHoldTimer)
-    countdownHoldTimer = null
-  }
-}
-
-/** ペーシング状態（キュー・保持タイマー・遅延中の完了トースト）を全破棄する */
-function resetCountdownPacing() {
-  discardCountdownQueue()
-  pendingSuccessToast = null
-}
-
-/**
- * キューの先頭を表示して MIN_HOLD の保持に入る。保持中なら何もしない
- * （保持タイマー満了時に再帰的に呼ばれて次を消化する）。
- * キューが掃けたら、遅延していた成功トーストを表示する。
- */
-function drainCountdownQueue() {
-  if (countdownHoldTimer !== null) return
-  const next = countdownQueue.shift()
-  if (next === undefined) {
-    // キューが掃けた（最後の数字も MIN_HOLD 表示済み）
-    const pending = pendingSuccessToast
-    if (pending !== null) {
-      pendingSuccessToast = null
-      displayPushToast(pending.message, pending.variant)
-    }
-    return
-  }
-  _pushToastCountdown = next
-  countdownHoldTimer = setTimeout(() => {
-    countdownHoldTimer = null
-    drainCountdownQueue()
-  }, PUSH_COUNTDOWN_MIN_HOLD_MS)
-}
+export {
+  pushToastState,
+  pushToastCountdown,
+  PUSH_COUNTDOWN_MIN_HOLD_MS,
+  showPushToast,
+  showPushCompletionToast,
+  showStickyPushToast,
+  setPushToastCountdown,
+  clearPushToast,
+} from './push-toast.svelte'
 
 /**
  * Pullトーストの状態
@@ -166,103 +87,6 @@ export const modalState = {
   set value(v: ModalState) {
     _modalState = v
   },
-}
-
-/**
- * Pushトーストを表示（push スロット共用の汎用入口）
- *
- * crud / move / share / io / OCR 等、Push 完了以外の通知もここを通るため、
- * variant を問わず常に即時表示する（ペーシングによる遅延はかけない）。
- * カウントダウン消化中に割り込んだ場合はキュー・保持タイマーを破棄する
- * （無関係トーストの下に数字が湧き出すのを防ぐ）が、遅延中の Push 完了
- * トースト（pending）は破棄せず、このトーストの2秒消滅時に表示される。
- */
-export function showPushToast(message: string, variant: 'success' | 'error' | '' = '') {
-  discardCountdownQueue()
-  displayPushToast(message, variant)
-}
-
-/**
- * Push 完了トーストを表示する（`actions/git.ts` の Push 完了経路専用、#238）。
- *
- * ペーシング対象はこの入口だけ: カウントダウンの消化中（数字を保持中または
- * キューあり）に success で呼ばれた場合は、最後の数字が MIN_HOLD 表示される
- * まで差し替えを遅延する（最悪ケース: キュー4件 + 保持中で +2秒弱の安全側
- * 遅延）。遅延中の完了トーストは drain 完了時、または割り込んだ汎用トースト
- * の2秒消滅時に必ず表示される。error（タイムアウト・失敗）は待たせられない
- * のでキュー・タイマー・pending を破棄して即時表示する。
- */
-export function showPushCompletionToast(message: string, variant: 'success' | 'error' = 'success') {
-  if (variant === 'success' && isCountdownDraining()) {
-    // drain 完了時（drainCountdownQueue）または汎用トーストの2秒消滅時に
-    // 表示される。完了トースト同士は後勝ち（最新の Push の結果が残る）
-    pendingSuccessToast = { message, variant }
-    return
-  }
-  resetCountdownPacing()
-  displayPushToast(message, variant)
-}
-
-/** Push トーストを実際に差し替えて2秒の自動消滅タイマーを張る（内部用） */
-function displayPushToast(message: string, variant: 'success' | 'error' | '') {
-  pushToastState.value = { message, variant }
-  // 完了/エラートーストへの差し替え時点でカウントダウンは役目を終える
-  _pushToastCountdown = null
-  setTimeout(() => {
-    // 自分が出したトーストがまだ表示中のときだけ触る。
-    // 後から別のトースト（sticky 含む）に差し替わっていたら触らない（後勝ち）。
-    if (pushToastState.value.message !== message) return
-    // 遅延中の Push 完了トーストがあれば、消す代わりにそれを表示する
-    // （pending の完了トーストは必ず最終的に表示されることの保証）
-    const pending = pendingSuccessToast
-    if (pending !== null) {
-      pendingSuccessToast = null
-      displayPushToast(pending.message, pending.variant)
-      return
-    }
-    pushToastState.value = { message: '', variant: '' }
-    // トーストを空にするならカウントダウンも残さない（不変条件を局所で保証）
-    _pushToastCountdown = null
-  }, 2000)
-}
-
-/**
- * Push の sticky トーストを表示する（自動消滅しない）。
- * isPushingBackground の間だけ出し、完了トースト（showPushCompletionToast）や
- * 他操作のトースト（showPushToast）、clearPushToast で差し替わる（後勝ち）。
- */
-export function showStickyPushToast(message: string) {
-  pushToastState.value = { message, variant: '' }
-  // 新しい Push の開始（トースト再表示）なので、カウントダウンとペーシング
-  // （キュー・保持タイマー・遅延中の成功トースト）を全リセットする。
-  // 単調減少ガードのリセットが許されるのはこのタイミングだけ（#238）
-  resetCountdownPacing()
-  _pushToastCountdown = null
-}
-
-/**
- * Push トーストのカウントダウン（残りステージ数）を更新する（#238）。
- *
- * 単調減少ガードはキュー投入時に「表示中の値とキュー末尾のうち最小」に対して
- * 適用する: 増加値・重複値は捨てる。リトライ・救済経路で内部的にステージが
- * 巻き戻っても数字は増えない。通過した値は即時反映ではなくペーシングキューに
- * 積まれ、各数字が最低 MIN_HOLD 表示されてから順に出る。
- */
-export function setPushToastCountdown(remainingStages: number) {
-  const floor =
-    countdownQueue.length > 0 ? countdownQueue[countdownQueue.length - 1] : _pushToastCountdown
-  if (clampMonotonicCountdown(floor, remainingStages) === floor) return
-  countdownQueue.push(remainingStages)
-  drainCountdownQueue()
-}
-
-/**
- * Pushトーストを即座に消す
- */
-export function clearPushToast() {
-  pushToastState.value = { message: '', variant: '' }
-  resetCountdownPacing()
-  _pushToastCountdown = null
 }
 
 /**


### PR DESCRIPTION
## 関連 Issue
Refs #226（ui.svelte.ts 分割。Phase 3・actions/git.ts は別 PR）

## 背景
#226 の追記対象。`ui/ui.svelte.ts`（451行・guidelines の ≈400行閾値超過）から、Push トーストのカウントダウン・ペーシング状態機械（約190行の凝集ユニット）を切り出す**振る舞い不変・公開 API 不変の純移動**。

## 変更内容
- **新規** `ui/push-toast.svelte.ts`（192行）— Push トーストの state（pushToastState/pushToastCountdown/PUSH_COUNTDOWN_MIN_HOLD_MS/内部キュー）＋ private helper（isCountdownDraining/drainCountdownQueue/displayPushToast 等）＋ public（showPushToast/showPushCompletionToast/showStickyPushToast/setPushToastCountdown/clearPushToast）をロジック不変で移動。`$state` rune のため `.svelte.ts` 拡張子。
- **変更** `ui.svelte.ts`（451 → 275 行）— 移動分を削除し push-toast.svelte.ts から**同名 re-export**。pull トースト・modal は据え置き。18箇所の既存 import 元（App.svelte/PaneView/actions/git.ts 他）は**無変更で動作**（公開 API 不変）。
- ToastState は pull トーストと共用のため ui.svelte.ts に単一定義を残し、push-toast.svelte.ts は `import type` で参照（型のみ＝実行時 import 循環なし）。
- **変更** `docs/development/architecture.md` — モジュール構成を更新。

## 振る舞い不変の根拠
既存 `ui.svelte.test.ts`（21件・カウントダウン単調減少ガード/キュー消化/pending success toast のペーシングを直接テスト）＋ app-state-heartbeat / pane-navigation-media 等の消費テストが**移動後も全緑**。

## テスト
- `npx vitest run src/lib/ui`: 21 passed
- `npm test`（全体）: 718 passed / 3 skipped
- svelte-check: 0 errors / prettier: clean

## 補足
純移動につき描画ロジックは不変。Push トーストのカウントダウン実挙動のライブ目視は、保留中の「PWA/Push 実機 golden path」パスに畳み込み可能。