### PR TITLE
refactor: 完全純粋な変換関数を metadata.ts/pull-map.ts へ抽出 (#226 Phase 3 PR-1)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -171,11 +171,13 @@ agasteer/
 │   │   ├── drag-drop.ts                 # ドラッグ&ドロップヘルパー
 │   │   ├── font.ts                      # カスタムフォント管理
 │   │   ├── github.ts                    # GitHub API統合（副作用層: push/pull/http）
-│   │   ├── github/                       # GitHub 純粋層/低レベル副作用層（Phase 1-2で分離）
+│   │   ├── github/                       # GitHub 純粋層/低レベル副作用層（Phase 1-3で分離）
 │   │   │   ├── paths.ts                 # パス定数・パス構築（純粋）
 │   │   │   ├── encoding.ts              # Base64/UTF-8変換（純粋）
 │   │   │   ├── sha.ts                   # Git blob SHA計算（純粋）
 │   │   │   ├── rate-limit.ts            # レート制限解析（純粋）
+│   │   │   ├── metadata.ts              # メタデータ正規化・安定化・push差分判定・pull正規化（純粋・Phase 3）
+│   │   │   ├── pull-map.ts              # pullパスの2階層折り畳み（純粋・Phase 3）
 │   │   │   └── http.ts                  # Contents API fetch/並列ワーカー/設定検証（副作用層・Phase 2）
 │   │   ├── media.ts                     # メディア同期層（副作用層: lazy作成/アップロード/キュー/キャッシュ）#242
 │   │   ├── media/                       # メディア純粋層（github/ の分割パターン踏襲）
@@ -342,7 +344,7 @@ agasteer/
 
 **GitHub同期:**
 
-- `github.ts`: GitHub API統合（ファイル保存、SHA取得、Git Tree API）。純粋層は `github/` 配下へ分離（Phase 1: paths/encoding/sha/rate-limit）。低レベル副作用ヘルパー（Contents API fetch/並列ワーカー/設定検証）は Phase 2 で `github/http.ts` へ純移動（非公開のまま github.ts が import）。push/pull の副作用層は github.ts に残し、純粋関数を re-export して公開 API を維持
+- `github.ts`: GitHub API統合（ファイル保存、SHA取得、Git Tree API）。純粋層は `github/` 配下へ分離（Phase 1: paths/encoding/sha/rate-limit）。低レベル副作用ヘルパー（Contents API fetch/並列ワーカー/設定検証）は Phase 2 で `github/http.ts` へ純移動（非公開のまま github.ts が import）。Phase 3 では push/pull 内の完全純粋関数（メタデータ正規化・安定文字列化・push差分判定 `detectChanges`・pull後正規化を `github/metadata.ts`、pullパスの2階層折り畳みを `github/pull-map.ts`）を純移動し、pull/pullArchive・push の重複を解消。push/pull の副作用層は github.ts に残し、純粋関数を re-export して公開 API を維持
 - `sync.ts`: Push/Pull処理の分離
 - `media.ts`: メディア同期層（#242）。別リポ `{owner}/{repo}-media` の lazy 作成・アップロード（pending キュー + online リトライ）・認証付き取得・LRU キャッシュ。`uploadMedia` は enqueue で即返し、実アップロードは背景の**グローバル直列チェーン**で流す（#247。同一リポへの並行 PUT が 409 になるのを直列化で回避。戻り値 `uploadDone: Promise<boolean>`。チェーン経路の fetch はタイムアウト付きで head-of-line blocking を防ぐ #252）。Push/Pull フロー・WorldType とは独立。純粋層は `media/` 配下（base64/naming/validation/lru）
 

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -25,7 +25,6 @@ import {
   ARCHIVE_METADATA_PATH,
   getBasePath,
   getMetadataPath,
-  sanitizePathPart,
   getFolderPath,
   getNotePath,
   buildPath,
@@ -34,6 +33,8 @@ import { parseRateLimitResponse, type RateLimitInfo } from './github/rate-limit'
 import { calculateGitBlobSha } from './github/sha'
 import { encodeContent, decodeBase64ToString } from './github/encoding'
 import { fetchGitHubContents, runWithConcurrency, validateGitHubSettings } from './github/http'
+import { normalizeMetadata, normalizePulledMetadata, detectChanges } from './github/metadata'
+import { collapseToTwoLevels } from './github/pull-map'
 import {
   PUSH_STAGE_REFS,
   PUSH_STAGE_BASE_TREE,
@@ -291,50 +292,6 @@ export async function pushAllWithTreeAPI(
     } catch (e) {
       console.warn('Push progress callback threw:', e)
     }
-  }
-
-  const stableStringify = (value: any): string => {
-    if (value === null || typeof value !== 'object') {
-      return JSON.stringify(value)
-    }
-    if (Array.isArray(value)) {
-      return `[${value.map(stableStringify).join(',')}]`
-    }
-    const keys = Object.keys(value)
-      .filter((k) => value[k] !== undefined)
-      .sort()
-    return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(',')}}`
-  }
-
-  const normalizeMetadata = (meta: Metadata, pushCountOverride?: number): Metadata => {
-    const normalized: Metadata = {
-      version: meta.version ?? 1,
-      pushCount: pushCountOverride ?? meta.pushCount ?? 0,
-      notes: {},
-      leaves: {},
-    }
-
-    const noteKeys = Object.keys(meta.notes || {}).sort()
-    for (const key of noteKeys) {
-      const n = meta.notes[key]
-      const entry: any = { id: n.id, order: n.order }
-      if (n.badgeIcon !== undefined) entry.badgeIcon = n.badgeIcon
-      if (n.badgeColor !== undefined) entry.badgeColor = n.badgeColor
-      normalized.notes[key] = entry
-    }
-
-    const leafKeys = Object.keys(meta.leaves || {}).sort()
-    for (const key of leafKeys) {
-      const l = meta.leaves[key]
-      // __priority__は仮想リーフなのでupdatedAtを固定値0に正規化（比較時の差分を防ぐ）
-      const updatedAt = key === PRIORITY_LEAF_ID ? 0 : l.updatedAt
-      const entry: any = { id: l.id, updatedAt, order: l.order }
-      if (l.badgeIcon !== undefined) entry.badgeIcon = l.badgeIcon
-      if (l.badgeColor !== undefined) entry.badgeColor = l.badgeColor
-      normalized.leaves[key] = entry
-    }
-
-    return normalized
   }
 
   // 設定の検証
@@ -806,22 +763,18 @@ export async function pushAllWithTreeAPI(
     }
 
     // metadata差分を含めて変更チェック（pushCountのインクリメントは除外）
-    const normalizedExisting = normalizeMetadata(existingMetadata, currentPushCount)
-    const normalizedCurrent = normalizeMetadata(metadata, currentPushCount)
-    const metadataChanged =
-      stableStringify(normalizedExisting) !== stableStringify(normalizedCurrent)
-
-    // アーカイブメタデータの差分チェック（ロード済みの場合のみ）
-    let archiveMetadataChanged = false
-    if (isArchiveLoaded && archiveNotes && archiveLeaves && archiveMeta) {
-      const normalizedExistingArchive = normalizeMetadata(existingArchiveMetadata, 0)
-      const normalizedCurrentArchive = normalizeMetadata(archiveMeta, 0)
-      archiveMetadataChanged =
-        stableStringify(normalizedExistingArchive) !== stableStringify(normalizedCurrentArchive)
-    }
-
-    const leafChanged = changedHomeLeafPaths.length > 0 || changedArchiveLeafPaths.length > 0
-    const hasAnyChanges = leafChanged || metadataChanged || archiveMetadataChanged
+    const { metadataChanged, archiveMetadataChanged, leafChanged, hasAnyChanges } = detectChanges({
+      existingMetadata,
+      metadata,
+      currentPushCount,
+      changedHomeLeafPaths,
+      changedArchiveLeafPaths,
+      isArchiveLoaded,
+      archiveNotes,
+      archiveLeaves,
+      archiveMeta,
+      existingArchiveMetadata,
+    })
     if (!hasAnyChanges) {
       // 変更がない場合は何もせずに成功を返す
       return {
@@ -1162,12 +1115,7 @@ export async function pullFromGitHub(
           const blobData = await blobRes.json()
           const jsonText = decodeBase64ToString(blobData.content)
           const parsed = JSON.parse(jsonText)
-          metadata = {
-            version: parsed.version || 1,
-            notes: parsed.notes || {},
-            leaves: parsed.leaves || {},
-            pushCount: parsed.pushCount || 0,
-          }
+          metadata = normalizePulledMetadata(parsed)
         }
       } catch (e) {
         console.warn(`${NOTES_METADATA_PATH} not found or invalid, using defaults`)
@@ -1175,11 +1123,6 @@ export async function pullFromGitHub(
     }
 
     const noteMap = new Map<string, Note>()
-
-    const collapseToTwoLevels = (parts: string[]): string[] => {
-      if (parts.length <= 2) return parts.map((p) => sanitizePathPart(p))
-      return [sanitizePathPart(parts[0]), sanitizePathPart(parts.slice(1).join('/'))]
-    }
 
     const ensureNotePath = (pathParts: string[]): string => {
       const collapsed = collapseToTwoLevels(pathParts)
@@ -1817,12 +1760,7 @@ export async function pullArchive(
           const blobData = await blobRes.json()
           const jsonText = decodeBase64ToString(blobData.content)
           const parsed = JSON.parse(jsonText)
-          metadata = {
-            version: parsed.version || 1,
-            notes: parsed.notes || {},
-            leaves: parsed.leaves || {},
-            pushCount: parsed.pushCount || 0,
-          }
+          metadata = normalizePulledMetadata(parsed)
         }
       } catch (e) {
         console.warn(`${ARCHIVE_METADATA_PATH} not found or invalid, using defaults`)
@@ -1831,13 +1769,8 @@ export async function pullArchive(
 
     const noteMap = new Map<string, Note>()
 
-    const collapseToTwoLevelsLocal = (parts: string[]): string[] => {
-      if (parts.length <= 2) return parts.map((p) => sanitizePathPart(p))
-      return [sanitizePathPart(parts[0]), sanitizePathPart(parts.slice(1).join('/'))]
-    }
-
     const ensureNotePath = (pathParts: string[]): string => {
-      const collapsed = collapseToTwoLevelsLocal(pathParts)
+      const collapsed = collapseToTwoLevels(pathParts)
       let parentId: string | undefined
       for (let i = 0; i < collapsed.length; i++) {
         const partial = collapsed.slice(0, i + 1).join('/')
@@ -1881,7 +1814,7 @@ export async function pullArchive(
       const relativePath = entry.path
         .replace(new RegExp(`^${ARCHIVE_PATH}/`), '')
         .replace(/\/\.gitkeep$/, '')
-      const parts = collapseToTwoLevelsLocal(relativePath.split('/').filter(Boolean))
+      const parts = collapseToTwoLevels(relativePath.split('/').filter(Boolean))
       if (parts.length === 0) continue
       ensureNotePath(parts)
     }
@@ -1899,7 +1832,7 @@ export async function pullArchive(
       const relativePath = entry.path.replace(new RegExp(`^${ARCHIVE_PATH}/`), '')
       const allParts = relativePath.split('/').filter(Boolean)
       const fileName = allParts.pop() || ''
-      const noteParts = collapseToTwoLevelsLocal(allParts)
+      const noteParts = collapseToTwoLevels(allParts)
       const title = fileName.replace(/\.md$/i, '') || 'Untitled'
       const noteId = ensureNotePath(noteParts)
       const leafPathOriginal = entry.path.replace(new RegExp(`^${ARCHIVE_PATH}/`), '')

--- a/src/lib/api/github/metadata.test.ts
+++ b/src/lib/api/github/metadata.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Metadata } from '../../types'
+
+// metadata.ts は PRIORITY_LEAF_ID を ../../utils から取り込み、その連鎖で
+// storage.ts が module 評価時に localStorage を触る。characterization テストと
+// 同じく import 前に localStorage をスタブしておく（純関数の検証には無関係）。
+const storageBacking = new Map<string, string>()
+;(globalThis as { localStorage?: unknown }).localStorage = {
+  getItem: (k: string) => storageBacking.get(k) ?? null,
+  setItem: (k: string, v: string) => void storageBacking.set(k, v),
+  removeItem: (k: string) => void storageBacking.delete(k),
+  clear: () => storageBacking.clear(),
+  key: (i: number) => Array.from(storageBacking.keys())[i] ?? null,
+  get length() {
+    return storageBacking.size
+  },
+}
+
+const { normalizeMetadata, stableStringify, detectChanges, normalizePulledMetadata } =
+  await import('./metadata')
+
+// PRIORITY_LEAF_ID の実値（../../utils）。normalizeMetadata が updatedAt=0 に固定する対象。
+const PRIORITY_LEAF_ID = '__priority__'
+
+const makeMeta = (over: Partial<Metadata> = {}): Metadata => ({
+  version: 1,
+  notes: {},
+  leaves: {},
+  pushCount: 0,
+  ...over,
+})
+
+describe('stableStringify', () => {
+  it('is independent of key insertion order', () => {
+    expect(stableStringify({ a: 1, b: 2 })).toBe(stableStringify({ b: 2, a: 1 }))
+  })
+
+  it('drops undefined-valued keys', () => {
+    expect(stableStringify({ a: 1, b: undefined })).toBe('{"a":1}')
+  })
+
+  it('serializes primitives and arrays like JSON', () => {
+    expect(stableStringify(null)).toBe('null')
+    expect(stableStringify(3)).toBe('3')
+    expect(stableStringify('x')).toBe('"x"')
+    expect(stableStringify([2, 1])).toBe('[2,1]')
+  })
+
+  it('recurses stably into nested objects', () => {
+    const a = { outer: { z: 1, a: 2 } }
+    const b = { outer: { a: 2, z: 1 } }
+    expect(stableStringify(a)).toBe(stableStringify(b))
+  })
+})
+
+describe('normalizeMetadata', () => {
+  it('sorts note and leaf keys for a stable output', () => {
+    const meta = makeMeta({
+      notes: {
+        b: { id: 'nb', order: 1 },
+        a: { id: 'na', order: 0 },
+      },
+      leaves: {
+        y: { id: 'ly', updatedAt: 10, order: 1 },
+        x: { id: 'lx', updatedAt: 5, order: 0 },
+      },
+    })
+    const n = normalizeMetadata(meta)
+    expect(Object.keys(n.notes)).toEqual(['a', 'b'])
+    expect(Object.keys(n.leaves)).toEqual(['x', 'y'])
+  })
+
+  it('keeps id/order and preserves badge fields only when defined', () => {
+    const meta = makeMeta({
+      notes: {
+        a: { id: 'na', order: 0, badgeIcon: 'star', badgeColor: 'red' },
+        b: { id: 'nb', order: 1 },
+      },
+    })
+    const n = normalizeMetadata(meta)
+    expect(n.notes.a).toEqual({ id: 'na', order: 0, badgeIcon: 'star', badgeColor: 'red' })
+    expect(n.notes.b).toEqual({ id: 'nb', order: 1 })
+    expect('badgeIcon' in n.notes.b).toBe(false)
+  })
+
+  it('pins __priority__ leaf updatedAt to 0 but keeps others', () => {
+    const meta = makeMeta({
+      leaves: {
+        [PRIORITY_LEAF_ID]: { id: 'p', updatedAt: 9999, order: 0 },
+        normal: { id: 'nrm', updatedAt: 42, order: 1 },
+      },
+    })
+    const n = normalizeMetadata(meta)
+    expect(n.leaves[PRIORITY_LEAF_ID].updatedAt).toBe(0)
+    expect(n.leaves.normal.updatedAt).toBe(42)
+  })
+
+  it('applies pushCountOverride and defaults version/pushCount', () => {
+    const n = normalizeMetadata({ notes: {}, leaves: {} } as unknown as Metadata, 7)
+    expect(n.version).toBe(1)
+    expect(n.pushCount).toBe(7)
+    const d = normalizeMetadata(makeMeta({ pushCount: 3 }))
+    expect(d.pushCount).toBe(3)
+  })
+
+  it('produces stringify-stable output regardless of source key order', () => {
+    const a = makeMeta({ notes: { b: { id: 'b', order: 1 }, a: { id: 'a', order: 0 } } })
+    const b = makeMeta({ notes: { a: { id: 'a', order: 0 }, b: { id: 'b', order: 1 } } })
+    expect(stableStringify(normalizeMetadata(a))).toBe(stableStringify(normalizeMetadata(b)))
+  })
+})
+
+describe('normalizePulledMetadata', () => {
+  it('fills defaults for a fully populated object', () => {
+    const parsed = { version: 2, notes: { a: { id: 'a', order: 0 } }, leaves: {}, pushCount: 5 }
+    expect(normalizePulledMetadata(parsed)).toEqual(parsed)
+  })
+
+  it('applies defaults for missing fields', () => {
+    expect(normalizePulledMetadata({})).toEqual({
+      version: 1,
+      notes: {},
+      leaves: {},
+      pushCount: 0,
+    })
+  })
+
+  it('falls back to defaults for null / undefined input', () => {
+    expect(normalizePulledMetadata(null)).toEqual({
+      version: 1,
+      notes: {},
+      leaves: {},
+      pushCount: 0,
+    })
+    expect(normalizePulledMetadata(undefined)).toEqual({
+      version: 1,
+      notes: {},
+      leaves: {},
+      pushCount: 0,
+    })
+  })
+
+  it('coerces falsy version/pushCount (0) to defaults, matching || semantics', () => {
+    const r = normalizePulledMetadata({ version: 0, pushCount: 0, notes: {}, leaves: {} })
+    expect(r.version).toBe(1)
+    expect(r.pushCount).toBe(0)
+  })
+})
+
+describe('detectChanges', () => {
+  const base = () => ({
+    existingMetadata: makeMeta(),
+    metadata: makeMeta(),
+    currentPushCount: 3,
+    changedHomeLeafPaths: [] as string[],
+    changedArchiveLeafPaths: [] as string[],
+    isArchiveLoaded: false,
+    archiveNotes: undefined,
+    archiveLeaves: undefined,
+    archiveMeta: undefined as Metadata | undefined,
+    existingArchiveMetadata: makeMeta(),
+  })
+
+  it('reports no changes when everything is identical', () => {
+    const r = detectChanges(base())
+    expect(r).toEqual({
+      metadataChanged: false,
+      archiveMetadataChanged: false,
+      leafChanged: false,
+      hasAnyChanges: false,
+    })
+  })
+
+  it('ignores pushCount differences (comparison excludes increment)', () => {
+    const input = base()
+    input.existingMetadata = makeMeta({ pushCount: 1 })
+    input.metadata = makeMeta({ pushCount: 99 })
+    expect(detectChanges(input).metadataChanged).toBe(false)
+  })
+
+  it('detects home metadata change', () => {
+    const input = base()
+    input.metadata = makeMeta({ notes: { a: { id: 'a', order: 0 } } })
+    const r = detectChanges(input)
+    expect(r.metadataChanged).toBe(true)
+    expect(r.hasAnyChanges).toBe(true)
+  })
+
+  it('detects leaf change via changed home paths', () => {
+    const input = base()
+    input.changedHomeLeafPaths = ['x.md']
+    const r = detectChanges(input)
+    expect(r.leafChanged).toBe(true)
+    expect(r.hasAnyChanges).toBe(true)
+  })
+
+  it('detects leaf change via changed archive paths', () => {
+    const input = base()
+    input.changedArchiveLeafPaths = ['a/y.md']
+    expect(detectChanges(input).leafChanged).toBe(true)
+  })
+
+  it('detects archive metadata change only when archive is loaded', () => {
+    const input = base()
+    input.existingArchiveMetadata = makeMeta()
+    input.archiveMeta = makeMeta({ notes: { a: { id: 'a', order: 0 } } })
+    input.archiveNotes = []
+    input.archiveLeaves = []
+
+    // ロードされていない → archive 差分は無視
+    input.isArchiveLoaded = false
+    expect(detectChanges(input).archiveMetadataChanged).toBe(false)
+
+    // ロード済み → 差分を検出
+    input.isArchiveLoaded = true
+    const r = detectChanges(input)
+    expect(r.archiveMetadataChanged).toBe(true)
+    expect(r.hasAnyChanges).toBe(true)
+  })
+
+  it('compares archive metadata with pushCount forced to 0 (asymmetry preserved)', () => {
+    const input = base()
+    input.isArchiveLoaded = true
+    input.archiveNotes = []
+    input.archiveLeaves = []
+    input.existingArchiveMetadata = makeMeta({ pushCount: 4 })
+    input.archiveMeta = makeMeta({ pushCount: 8 })
+    // pushCount 差のみ → archive は常に 0 で比較するので変化なし
+    expect(detectChanges(input).archiveMetadataChanged).toBe(false)
+  })
+})

--- a/src/lib/api/github/metadata.test.ts
+++ b/src/lib/api/github/metadata.test.ts
@@ -126,19 +126,13 @@ describe('normalizePulledMetadata', () => {
     })
   })
 
-  it('falls back to defaults for null / undefined input', () => {
-    expect(normalizePulledMetadata(null)).toEqual({
-      version: 1,
-      notes: {},
-      leaves: {},
-      pushCount: 0,
-    })
-    expect(normalizePulledMetadata(undefined)).toEqual({
-      version: 1,
-      notes: {},
-      leaves: {},
-      pushCount: 0,
-    })
+  it('throws on null / undefined input (元インライン実装の parsed.version 直読みと等価)', () => {
+    // 旧実装は JSON.parse 結果に対し parsed.version を直読みしていたため、
+    // リテラル null（JSON.parse('null')）や undefined ではプロパティ参照で throw し、
+    // 呼び出し側 fetch 層の try/catch が warn + defaults に落としていた。
+    // ここで握り潰すと warn 経路が消えるため、純移動として throw を保存する。
+    expect(() => normalizePulledMetadata(null)).toThrow()
+    expect(() => normalizePulledMetadata(undefined)).toThrow()
   })
 
   it('coerces falsy version/pushCount (0) to defaults, matching || semantics', () => {

--- a/src/lib/api/github/metadata.ts
+++ b/src/lib/api/github/metadata.ts
@@ -1,0 +1,140 @@
+/**
+ * GitHub 同期のメタデータ正規化・差分判定（純粋層）
+ *
+ * fetch・settings・IO に一切触れない純粋関数のみを置く。
+ * github.ts から純移動（Phase 3 / #226）。振る舞いは不変。
+ */
+
+import type { Metadata } from '../../types'
+import { PRIORITY_LEAF_ID } from '../../utils'
+
+/**
+ * キー順に依存しない安定した文字列化（差分比較用）。
+ * undefined を持つキーは除外し、オブジェクトのキーをソートしてから直列化する。
+ */
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort()
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`
+}
+
+/**
+ * メタデータを比較用に正規化する。
+ * - notes/leaves を id/order/badge のみに絞り、キーをソート
+ * - __priority__ は仮想リーフなので updatedAt を固定値 0 に正規化（比較時の差分を防ぐ）
+ * - pushCount は pushCountOverride があればそれを優先
+ */
+export function normalizeMetadata(meta: Metadata, pushCountOverride?: number): Metadata {
+  const normalized: Metadata = {
+    version: meta.version ?? 1,
+    pushCount: pushCountOverride ?? meta.pushCount ?? 0,
+    notes: {},
+    leaves: {},
+  }
+
+  const noteKeys = Object.keys(meta.notes || {}).sort()
+  for (const key of noteKeys) {
+    const n = meta.notes[key]
+    const entry: Metadata['notes'][string] = { id: n.id, order: n.order }
+    if (n.badgeIcon !== undefined) entry.badgeIcon = n.badgeIcon
+    if (n.badgeColor !== undefined) entry.badgeColor = n.badgeColor
+    normalized.notes[key] = entry
+  }
+
+  const leafKeys = Object.keys(meta.leaves || {}).sort()
+  for (const key of leafKeys) {
+    const l = meta.leaves[key]
+    // __priority__は仮想リーフなのでupdatedAtを固定値0に正規化（比較時の差分を防ぐ）
+    const updatedAt = key === PRIORITY_LEAF_ID ? 0 : l.updatedAt
+    const entry: Metadata['leaves'][string] = { id: l.id, updatedAt, order: l.order }
+    if (l.badgeIcon !== undefined) entry.badgeIcon = l.badgeIcon
+    if (l.badgeColor !== undefined) entry.badgeColor = l.badgeColor
+    normalized.leaves[key] = entry
+  }
+
+  return normalized
+}
+
+/**
+ * Pull 側で decode 済みの JSON 値をメタデータへ正規化する。
+ * JSON.parse とその try/catch は呼び出し側の fetch 層に残し、この関数は
+ * parse 済み値を受けてデフォルト補完するだけ（振る舞い不変）。
+ */
+export function normalizePulledMetadata(parsed: unknown): Metadata {
+  const p = (parsed ?? {}) as Partial<Metadata>
+  return {
+    version: p.version || 1,
+    notes: p.notes || {},
+    leaves: p.leaves || {},
+    pushCount: p.pushCount || 0,
+  }
+}
+
+/** detectChanges の入力（既に算出済みの値・両メタデータのみ。fetch/sha は持ち込まない） */
+export interface DetectChangesInput {
+  existingMetadata: Metadata
+  metadata: Metadata
+  currentPushCount: number
+  changedHomeLeafPaths: string[]
+  changedArchiveLeafPaths: string[]
+  isArchiveLoaded: boolean
+  archiveNotes: unknown
+  archiveLeaves: unknown
+  archiveMeta: Metadata | undefined
+  existingArchiveMetadata: Metadata
+}
+
+export interface DetectChangesResult {
+  metadataChanged: boolean
+  archiveMetadataChanged: boolean
+  leafChanged: boolean
+  hasAnyChanges: boolean
+}
+
+/**
+ * push 時の変更判定（pushCount のインクリメントは除外）。
+ * home metadata は normalizeMetadata(…, currentPushCount) 経由、archive metadata は
+ * normalizeMetadata(…, 0) 経由で比較する（「書くのは raw・比較は normalized」
+ * 「pushCount は home のみ +1・archive は常に 0」の非対称を保存）。
+ */
+export function detectChanges(input: DetectChangesInput): DetectChangesResult {
+  const {
+    existingMetadata,
+    metadata,
+    currentPushCount,
+    changedHomeLeafPaths,
+    changedArchiveLeafPaths,
+    isArchiveLoaded,
+    archiveNotes,
+    archiveLeaves,
+    archiveMeta,
+    existingArchiveMetadata,
+  } = input
+
+  // metadata差分を含めて変更チェック（pushCountのインクリメントは除外）
+  const normalizedExisting = normalizeMetadata(existingMetadata, currentPushCount)
+  const normalizedCurrent = normalizeMetadata(metadata, currentPushCount)
+  const metadataChanged = stableStringify(normalizedExisting) !== stableStringify(normalizedCurrent)
+
+  // アーカイブメタデータの差分チェック（ロード済みの場合のみ）
+  let archiveMetadataChanged = false
+  if (isArchiveLoaded && archiveNotes && archiveLeaves && archiveMeta) {
+    const normalizedExistingArchive = normalizeMetadata(existingArchiveMetadata, 0)
+    const normalizedCurrentArchive = normalizeMetadata(archiveMeta, 0)
+    archiveMetadataChanged =
+      stableStringify(normalizedExistingArchive) !== stableStringify(normalizedCurrentArchive)
+  }
+
+  const leafChanged = changedHomeLeafPaths.length > 0 || changedArchiveLeafPaths.length > 0
+  const hasAnyChanges = leafChanged || metadataChanged || archiveMetadataChanged
+
+  return { metadataChanged, archiveMetadataChanged, leafChanged, hasAnyChanges }
+}

--- a/src/lib/api/github/metadata.ts
+++ b/src/lib/api/github/metadata.ts
@@ -69,7 +69,10 @@ export function normalizeMetadata(meta: Metadata, pushCountOverride?: number): M
  * parse 済み値を受けてデフォルト補完するだけ（振る舞い不変）。
  */
 export function normalizePulledMetadata(parsed: unknown): Metadata {
-  const p = (parsed ?? {}) as Partial<Metadata>
+  // 元インライン実装（parsed.version 直読み）と等価に保つ: parsed が null/undefined の
+  // 場合はプロパティ参照で throw し、呼び出し側 fetch 層の try/catch が warn + defaults に落とす。
+  // ここで `?? {}` して握り潰すと、その warn 経路が消えて振る舞いが変わる。
+  const p = parsed as Partial<Metadata>
   return {
     version: p.version || 1,
     notes: p.notes || {},

--- a/src/lib/api/github/pull-map.test.ts
+++ b/src/lib/api/github/pull-map.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { collapseToTwoLevels } from './pull-map'
+
+describe('collapseToTwoLevels', () => {
+  it('returns an empty array unchanged', () => {
+    expect(collapseToTwoLevels([])).toEqual([])
+  })
+
+  it('keeps a single level', () => {
+    expect(collapseToTwoLevels(['a'])).toEqual(['a'])
+  })
+
+  it('keeps two levels', () => {
+    expect(collapseToTwoLevels(['a', 'b'])).toEqual(['a', 'b'])
+  })
+
+  it('collapses three levels into two, joining the tail with sanitize (/ -> -)', () => {
+    expect(collapseToTwoLevels(['a', 'b', 'c'])).toEqual(['a', 'b-c'])
+  })
+
+  it('collapses four or more levels into the first + sanitized remainder', () => {
+    expect(collapseToTwoLevels(['a', 'b', 'c', 'd'])).toEqual(['a', 'b-c-d'])
+  })
+
+  it('sanitizes each part even when not collapsing', () => {
+    expect(collapseToTwoLevels(['a/b', 'c'])).toEqual(['a-b', 'c'])
+  })
+})

--- a/src/lib/api/github/pull-map.ts
+++ b/src/lib/api/github/pull-map.ts
@@ -1,0 +1,18 @@
+/**
+ * GitHub Pull のパス折り畳み（純粋層）
+ *
+ * fetch・settings・IO に一切触れない純粋関数のみを置く。
+ * github.ts から純移動（Phase 3 / #226）。振る舞いは不変。
+ */
+
+import { sanitizePathPart } from './paths'
+
+/**
+ * ノートパス（ファイル名を除いた parts）を最大2階層へ折り畳む。
+ * 3階層以上は先頭と残りを '/' で結合した1つにまとめ、各要素は sanitizePathPart を通す
+ * （collapse 後の '/'→'-' 変換は仕様）。
+ */
+export function collapseToTwoLevels(parts: string[]): string[] {
+  if (parts.length <= 2) return parts.map((p) => sanitizePathPart(p))
+  return [sanitizePathPart(parts[0]), sanitizePathPart(parts.slice(1).join('/'))]
+}


### PR DESCRIPTION
## 関連 Issue
Refs #226（Phase 3 の PR-1。PR-2=pull 側 noteMap/leafTargets、PR-3=push tree 構築は別 PR）

## 背景
god-file `github.ts`（2022行）の2大巨大関数（pushAllWithTreeAPI/pullFromGitHub）から純粋変換を抽出する Phase 3 の第一歩。最も低リスクな**クロージャ非依存の完全純粋関数のみ**を純移動する。安全網は #231 で整備した characterization テスト。

## 変更内容（振る舞い不変・公開 API 不変の純移動）
- **新規** `github/metadata.ts` — `normalizeMetadata` / `stableStringify` / `normalizePulledMetadata` / `detectChanges`
- **新規** `github/pull-map.ts` — `collapseToTwoLevels`
- **変更** `github.ts` — 定義削除し import 呼び出しに差し替え。pull/pullArchive で重複していた metadata 正規化・2階層 collapse を集約。**2022 → 1955 行**。
- **新規** 直接単体テスト26件（metadata.test 20 / pull-map.test 6）
- **変更** `architecture.md` にモジュール追記

## 保存した非対称ロジック
- `normalizeMetadata` の `__priority__` 仮想リーフ updatedAt=0 固定（差分安定化）
- push の archive metadata.json は raw で書き、差分判定は normalized で比較（pushCount は home のみ +1・archive は 0）

## 振る舞い不変の根拠
既存 characterization（github-push / github-pull / concurrency / status）が**全緑**。afterEach の `mock.assertDrained()` で fetch 回数の変化も検知。実際、抽出中に `leafChanged` の分割代入漏れを characterization が即赤で検知し修正済み（回帰検知が機能）。

## テスト
- `npx vitest run src/lib/api/github`: 11 files / 188 passed
- `npm test`（全体）: 744 passed / 3 skipped
- svelte-check: 0 errors / prettier: clean

## 補足
純移動につき fetch 挙動は不変。Phase 3 全体の実機 push/pull golden path 検証（使い捨て `kako-jun/agasteer-test`・トークンは環境変数）は PR-3（push tree 構築）完了時にまとめて実施予定。