### PR TITLE
refactor: pull/pullArchive の重複マッピングを pull-map.ts へ集約 (#226 Phase 3 PR-2)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -177,7 +177,7 @@ agasteer/
 │   │   │   ├── sha.ts                   # Git blob SHA計算（純粋）
 │   │   │   ├── rate-limit.ts            # レート制限解析（純粋）
 │   │   │   ├── metadata.ts              # メタデータ正規化・安定化・push差分判定・pull正規化（純粋・Phase 3）
-│   │   │   ├── pull-map.ts              # pullパスの2階層折り畳み（純粋・Phase 3）
+│   │   │   ├── pull-map.ts              # pullのパス折り畳み＋notes/leavesスケルトン構築（純粋・Phase 3 PR-1/PR-2）
 │   │   │   └── http.ts                  # Contents API fetch/並列ワーカー/設定検証（副作用層・Phase 2）
 │   │   ├── media.ts                     # メディア同期層（副作用層: lazy作成/アップロード/キュー/キャッシュ）#242
 │   │   ├── media/                       # メディア純粋層（github/ の分割パターン踏襲）
@@ -344,7 +344,7 @@ agasteer/
 
 **GitHub同期:**
 
-- `github.ts`: GitHub API統合（ファイル保存、SHA取得、Git Tree API）。純粋層は `github/` 配下へ分離（Phase 1: paths/encoding/sha/rate-limit）。低レベル副作用ヘルパー（Contents API fetch/並列ワーカー/設定検証）は Phase 2 で `github/http.ts` へ純移動（非公開のまま github.ts が import）。Phase 3 では push/pull 内の完全純粋関数（メタデータ正規化・安定文字列化・push差分判定 `detectChanges`・pull後正規化を `github/metadata.ts`、pullパスの2階層折り畳みを `github/pull-map.ts`）を純移動し、pull/pullArchive・push の重複を解消。push/pull の副作用層は github.ts に残し、純粋関数を re-export して公開 API を維持
+- `github.ts`: GitHub API統合（ファイル保存、SHA取得、Git Tree API）。純粋層は `github/` 配下へ分離（Phase 1: paths/encoding/sha/rate-limit）。低レベル副作用ヘルパー（Contents API fetch/並列ワーカー/設定検証）は Phase 2 で `github/http.ts` へ純移動（非公開のまま github.ts が import）。Phase 3 では push/pull 内の完全純粋関数（メタデータ正規化・安定文字列化・push差分判定 `detectChanges`・pull後正規化を `github/metadata.ts`、pullパスの2階層折り畳みを `github/pull-map.ts`）を純移動し、pull/pullArchive・push の重複を解消。PR-2 では pull 側の tree→スケルトン構築ロジック（`ensureNotePath`／`buildLeafTargets`／`getLeafPriority`／`buildLeafFromTarget`）を `github/pull-map.ts` に集約し、pullFromGitHub と pullArchive の重複インラインコードを解消（noteMap の mutate は保存、uuid/Date.now は optional 注入でデフォルト現状維持、副作用オーケストレーションは github.ts に残置）。push/pull の副作用層は github.ts に残し、純粋関数を re-export して公開 API を維持
 - `sync.ts`: Push/Pull処理の分離
 - `media.ts`: メディア同期層（#242）。別リポ `{owner}/{repo}-media` の lazy 作成・アップロード（pending キュー + online リトライ）・認証付き取得・LRU キャッシュ。`uploadMedia` は enqueue で即返し、実アップロードは背景の**グローバル直列チェーン**で流す（#247。同一リポへの並行 PUT が 409 になるのを直列化で回避。戻り値 `uploadDone: Promise<boolean>`。チェーン経路の fetch はタイムアウト付きで head-of-line blocking を防ぐ #252）。Push/Pull フロー・WorldType とは独立。純粋層は `media/` 配下（base64/naming/validation/lru）
 

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -34,7 +34,13 @@ import { calculateGitBlobSha } from './github/sha'
 import { encodeContent, decodeBase64ToString } from './github/encoding'
 import { fetchGitHubContents, runWithConcurrency, validateGitHubSettings } from './github/http'
 import { normalizeMetadata, normalizePulledMetadata, detectChanges } from './github/metadata'
-import { collapseToTwoLevels } from './github/pull-map'
+import {
+  buildLeafFromTarget,
+  buildLeafTargets,
+  collapseToTwoLevels,
+  ensureNotePath,
+  getLeafPriority,
+} from './github/pull-map'
 import {
   PUSH_STAGE_REFS,
   PUSH_STAGE_BASE_TREE,
@@ -1124,36 +1130,6 @@ export async function pullFromGitHub(
 
     const noteMap = new Map<string, Note>()
 
-    const ensureNotePath = (pathParts: string[]): string => {
-      const collapsed = collapseToTwoLevels(pathParts)
-      let parentId: string | undefined
-      for (let i = 0; i < collapsed.length; i++) {
-        const partial = collapsed.slice(0, i + 1).join('/')
-        if (noteMap.has(partial)) {
-          parentId = noteMap.get(partial)!.id
-          continue
-        }
-        // metadata.jsonからメタ情報を取得
-        const meta = metadata.notes[partial] || {
-          id: crypto.randomUUID(),
-          order: noteMap.size,
-          badgeIcon: undefined,
-          badgeColor: undefined,
-        }
-        const note: Note = {
-          id: meta.id,
-          name: collapsed[i],
-          parentId,
-          order: meta.order,
-          badgeIcon: meta.badgeIcon,
-          badgeColor: meta.badgeColor,
-        }
-        noteMap.set(partial, note)
-        parentId = note.id
-      }
-      return parentId || ''
-    }
-
     // ベースパスのプレフィックスを作成（末尾スラッシュ付き）
     const basePathPrefix = `${NOTES_PATH}/`
     const basePathGitkeep = `${NOTES_PATH}/.gitkeep`
@@ -1175,7 +1151,7 @@ export async function pullFromGitHub(
       if (parts.length === 0) continue
 
       // .gitkeepがあるディレクトリのノートを復元
-      ensureNotePath(parts)
+      ensureNotePath({ pathParts: parts, noteMap, metadata })
     }
 
     // 次に.mdファイル（リーフ）を復元
@@ -1188,31 +1164,11 @@ export async function pullFromGitHub(
     )
 
     // コンテンツ取得用のターゲットを事前に作成（メタデータ取得はここで済ませる）
-    const leafTargets = notePaths.map((entry, idx) => {
-      const relativePath = entry.path.replace(new RegExp(`^${NOTES_PATH}/`), '')
-      const allParts = relativePath.split('/').filter(Boolean)
-      // ファイル名を先に分離してから、ノートパス部分だけをcollapseする
-      const fileName = allParts.pop() || ''
-      const noteParts = collapseToTwoLevels(allParts)
-      const title = fileName.replace(/\.md$/i, '') || 'Untitled'
-      const noteId = ensureNotePath(noteParts)
-      const leafPathOriginal = entry.path.replace(new RegExp(`^${NOTES_PATH}/`), '')
-      const leafPathCollapsed = [...noteParts, fileName].join('/')
-      const leafMeta = metadata.leaves[leafPathCollapsed] ||
-        metadata.leaves[leafPathOriginal] || {
-          id: crypto.randomUUID(),
-          updatedAt: Date.now(),
-          order: idx,
-          badgeIcon: undefined,
-          badgeColor: undefined,
-        }
-      return {
-        entry,
-        title,
-        noteId,
-        leafMeta,
-        relativePath: leafPathCollapsed,
-      }
+    const leafTargets = buildLeafTargets({
+      entries: notePaths,
+      basePath: NOTES_PATH,
+      metadata,
+      noteMap,
     })
 
     // ノート構造確定 → onStructureコールバック（優先情報を返してもらう）
@@ -1233,15 +1189,10 @@ export async function pullFromGitHub(
     // 優先度でソート（priorityがvoidの場合は空セット）
     const priorityLeafPaths = new Set(priority && 'leafPaths' in priority ? priority.leafPaths : [])
     const priorityNoteIds = new Set(priority && 'noteIds' in priority ? priority.noteIds : [])
+    const prioritySets = { leafPaths: priorityLeafPaths, noteIds: priorityNoteIds }
 
-    const getPriority = (target: (typeof leafTargets)[0]): number => {
-      // 第1優先: URLで指定されたリーフ
-      if (priorityLeafPaths.has(target.relativePath)) return 0
-      // 第2優先: URLで指定されたリーフと同じノート配下
-      if (priorityNoteIds.has(target.noteId)) return 1
-      // その他
-      return 2
-    }
+    const getPriority = (target: (typeof leafTargets)[0]): number =>
+      getLeafPriority(target, prioritySets)
 
     const sortedTargets = [...leafTargets].sort((a, b) => {
       const priorityDiff = getPriority(a) - getPriority(b)
@@ -1271,17 +1222,7 @@ export async function pullFromGitHub(
         // blob SHAキャッシュ: IndexedDBのSHAと一致すればfetchスキップ
         const cached = options?.cachedLeaves?.get(target.entry.sha)
         if (cached?.content) {
-          const leaf: Leaf = {
-            id: target.leafMeta.id,
-            title: target.title,
-            noteId: target.noteId,
-            content: cached.content,
-            updatedAt: target.leafMeta.updatedAt,
-            order: target.leafMeta.order,
-            badgeIcon: target.leafMeta.badgeIcon,
-            badgeColor: target.leafMeta.badgeColor,
-            blobSha: target.entry.sha,
-          }
+          const leaf = buildLeafFromTarget(target, cached.content, target.entry.sha)
           options?.onLeaf?.(leaf)
           if (getPriority(target) === 0) {
             priority1Completed++
@@ -1309,17 +1250,7 @@ export async function pullFromGitHub(
         }
         const content = await contentRes.text()
 
-        const leaf: Leaf = {
-          id: target.leafMeta.id,
-          title: target.title,
-          noteId: target.noteId,
-          content,
-          updatedAt: target.leafMeta.updatedAt,
-          order: target.leafMeta.order,
-          badgeIcon: target.leafMeta.badgeIcon,
-          badgeColor: target.leafMeta.badgeColor,
-          blobSha: target.entry.sha,
-        }
+        const leaf = buildLeafFromTarget(target, content, target.entry.sha)
 
         // 各リーフ取得完了時のコールバック
         options?.onLeaf?.(leaf)
@@ -1769,35 +1700,6 @@ export async function pullArchive(
 
     const noteMap = new Map<string, Note>()
 
-    const ensureNotePath = (pathParts: string[]): string => {
-      const collapsed = collapseToTwoLevels(pathParts)
-      let parentId: string | undefined
-      for (let i = 0; i < collapsed.length; i++) {
-        const partial = collapsed.slice(0, i + 1).join('/')
-        if (noteMap.has(partial)) {
-          parentId = noteMap.get(partial)!.id
-          continue
-        }
-        const meta = metadata.notes[partial] || {
-          id: crypto.randomUUID(),
-          order: noteMap.size,
-          badgeIcon: undefined,
-          badgeColor: undefined,
-        }
-        const note: Note = {
-          id: meta.id,
-          name: collapsed[i],
-          parentId,
-          order: meta.order,
-          badgeIcon: meta.badgeIcon,
-          badgeColor: meta.badgeColor,
-        }
-        noteMap.set(partial, note)
-        parentId = note.id
-      }
-      return parentId || ''
-    }
-
     const basePathPrefix = `${ARCHIVE_PATH}/`
     const basePathGitkeep = `${ARCHIVE_PATH}/.gitkeep`
 
@@ -1816,7 +1718,7 @@ export async function pullArchive(
         .replace(/\/\.gitkeep$/, '')
       const parts = collapseToTwoLevels(relativePath.split('/').filter(Boolean))
       if (parts.length === 0) continue
-      ensureNotePath(parts)
+      ensureNotePath({ pathParts: parts, noteMap, metadata })
     }
 
     // .mdファイル（リーフ）を復元
@@ -1828,30 +1730,11 @@ export async function pullArchive(
         !e.path.endsWith('.gitkeep')
     )
 
-    const leafTargets = leafPaths.map((entry, idx) => {
-      const relativePath = entry.path.replace(new RegExp(`^${ARCHIVE_PATH}/`), '')
-      const allParts = relativePath.split('/').filter(Boolean)
-      const fileName = allParts.pop() || ''
-      const noteParts = collapseToTwoLevels(allParts)
-      const title = fileName.replace(/\.md$/i, '') || 'Untitled'
-      const noteId = ensureNotePath(noteParts)
-      const leafPathOriginal = entry.path.replace(new RegExp(`^${ARCHIVE_PATH}/`), '')
-      const leafPathCollapsed = [...noteParts, fileName].join('/')
-      const leafMeta = metadata.leaves[leafPathCollapsed] ||
-        metadata.leaves[leafPathOriginal] || {
-          id: crypto.randomUUID(),
-          updatedAt: Date.now(),
-          order: idx,
-          badgeIcon: undefined,
-          badgeColor: undefined,
-        }
-      return {
-        entry,
-        title,
-        noteId,
-        leafMeta,
-        relativePath: leafPathCollapsed,
-      }
+    const leafTargets = buildLeafTargets({
+      entries: leafPaths,
+      basePath: ARCHIVE_PATH,
+      metadata,
+      noteMap,
     })
 
     // リーフを並列取得
@@ -1865,17 +1748,7 @@ export async function pullArchive(
         // blob SHAキャッシュ: IndexedDBのSHAと一致すればfetchスキップ
         const cached = options.cachedLeaves?.get(target.entry.sha)
         if (cached?.content) {
-          const leaf: Leaf = {
-            id: target.leafMeta.id,
-            title: target.title,
-            noteId: target.noteId,
-            content: cached.content,
-            updatedAt: target.leafMeta.updatedAt,
-            order: target.leafMeta.order,
-            badgeIcon: target.leafMeta.badgeIcon,
-            badgeColor: target.leafMeta.badgeColor,
-            blobSha: target.entry.sha,
-          }
+          const leaf = buildLeafFromTarget(target, cached.content, target.entry.sha)
           options.onLeafFetched?.(leaf)
           return leaf
         }
@@ -1896,17 +1769,7 @@ export async function pullArchive(
         }
         const content = await contentRes.text()
 
-        const leaf: Leaf = {
-          id: target.leafMeta.id,
-          title: target.title,
-          noteId: target.noteId,
-          content,
-          updatedAt: target.leafMeta.updatedAt,
-          order: target.leafMeta.order,
-          badgeIcon: target.leafMeta.badgeIcon,
-          badgeColor: target.leafMeta.badgeColor,
-          blobSha: target.entry.sha,
-        }
+        const leaf = buildLeafFromTarget(target, content, target.entry.sha)
 
         // 進捗報告
         options.onLeafFetched?.(leaf)

--- a/src/lib/api/github/pull-map.test.ts
+++ b/src/lib/api/github/pull-map.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from 'vitest'
 
-import { collapseToTwoLevels } from './pull-map'
+import type { Metadata, Note } from '../../types'
+import {
+  buildLeafFromTarget,
+  buildLeafTargets,
+  collapseToTwoLevels,
+  ensureNotePath,
+  getLeafPriority,
+  type LeafTarget,
+} from './pull-map'
+
+const emptyMetadata = (): Metadata => ({ version: 1, notes: {}, leaves: {}, pushCount: 0 })
+
+const makeTarget = (overrides: Partial<LeafTarget> = {}): LeafTarget => ({
+  entry: { path: 'p', type: 'blob', sha: 'sha1' },
+  title: 'Title',
+  noteId: 'note-1',
+  leafMeta: { id: 'leaf-1', updatedAt: 111, order: 0, badgeIcon: undefined, badgeColor: undefined },
+  relativePath: 'a/Title.md',
+  ...overrides,
+})
 
 describe('collapseToTwoLevels', () => {
   it('returns an empty array unchanged', () => {
@@ -25,5 +44,155 @@ describe('collapseToTwoLevels', () => {
 
   it('sanitizes each part even when not collapsing', () => {
     expect(collapseToTwoLevels(['a/b', 'c'])).toEqual(['a-b', 'c'])
+  })
+})
+
+describe('ensureNotePath', () => {
+  it('reuses id/order/badges from metadata.notes when present', () => {
+    const metadata = emptyMetadata()
+    metadata.notes = { a: { id: 'meta-a', order: 5, badgeIcon: 'star', badgeColor: 'red' } }
+    const noteMap = new Map<string, Note>()
+    const noteId = ensureNotePath({
+      pathParts: ['a'],
+      noteMap,
+      metadata,
+      idGenerator: () => 'GEN',
+    })
+    expect(noteId).toBe('meta-a')
+    const note = noteMap.get('a')!
+    expect(note).toMatchObject({ id: 'meta-a', name: 'a', order: 5, badgeIcon: 'star' })
+  })
+
+  it('generates a new id via idGenerator when metadata is missing', () => {
+    const noteMap = new Map<string, Note>()
+    const noteId = ensureNotePath({
+      pathParts: ['a'],
+      noteMap,
+      metadata: emptyMetadata(),
+      idGenerator: () => 'FIXED-ID',
+    })
+    expect(noteId).toBe('FIXED-ID')
+    expect(noteMap.get('a')!.order).toBe(0)
+  })
+
+  it('builds a parent chain and returns the leaf note id, mutating noteMap', () => {
+    const noteMap = new Map<string, Note>()
+    let n = 0
+    const noteId = ensureNotePath({
+      pathParts: ['a', 'b'],
+      noteMap,
+      metadata: emptyMetadata(),
+      idGenerator: () => `id-${n++}`,
+    })
+    expect(noteMap.get('a')!.parentId).toBeUndefined()
+    expect(noteMap.get('a/b')!.parentId).toBe(noteMap.get('a')!.id)
+    expect(noteId).toBe(noteMap.get('a/b')!.id)
+  })
+
+  it('collapses 3+ levels into two before registering', () => {
+    const noteMap = new Map<string, Note>()
+    ensureNotePath({
+      pathParts: ['a', 'b', 'c'],
+      noteMap,
+      metadata: emptyMetadata(),
+      idGenerator: () => 'x',
+    })
+    expect([...noteMap.keys()]).toEqual(['a', 'a/b-c'])
+  })
+})
+
+describe('buildLeafTargets', () => {
+  it('maps path/fileName/title and calls ensureNotePath', () => {
+    const noteMap = new Map<string, Note>()
+    const targets = buildLeafTargets({
+      entries: [{ path: '.agasteer/notes/a/Hello.md', type: 'blob', sha: 's1' }],
+      basePath: '.agasteer/notes',
+      metadata: emptyMetadata(),
+      noteMap,
+      idGenerator: () => 'UUID',
+      now: () => 999,
+    })
+    expect(targets).toHaveLength(1)
+    expect(targets[0]).toMatchObject({
+      title: 'Hello',
+      relativePath: 'a/Hello.md',
+      noteId: noteMap.get('a')!.id,
+    })
+    expect(targets[0].leafMeta).toMatchObject({ id: 'UUID', updatedAt: 999, order: 0 })
+  })
+
+  it('collapses a deep note path before the filename', () => {
+    const noteMap = new Map<string, Note>()
+    const targets = buildLeafTargets({
+      entries: [{ path: '.agasteer/notes/a/b/c/Deep.md', type: 'blob', sha: 's1' }],
+      basePath: '.agasteer/notes',
+      metadata: emptyMetadata(),
+      noteMap,
+      idGenerator: () => 'UUID',
+      now: () => 1,
+    })
+    expect(targets[0].relativePath).toBe('a/b-c/Deep.md')
+  })
+
+  it('prefers the collapsed leaf key then the original key in metadata.leaves', () => {
+    const noteMap = new Map<string, Note>()
+    const metadata = emptyMetadata()
+    metadata.leaves = {
+      'a/b-c/Deep.md': { id: 'collapsed', updatedAt: 10, order: 3 },
+      'a/b/c/Deep.md': { id: 'original', updatedAt: 20, order: 4 },
+    }
+    const [t] = buildLeafTargets({
+      entries: [{ path: '.agasteer/notes/a/b/c/Deep.md', type: 'blob', sha: 's1' }],
+      basePath: '.agasteer/notes',
+      metadata,
+      noteMap,
+    })
+    expect(t.leafMeta.id).toBe('collapsed')
+  })
+
+  it('falls back to the original leaf key when the collapsed key is absent', () => {
+    const noteMap = new Map<string, Note>()
+    const metadata = emptyMetadata()
+    metadata.leaves = { 'a/Hello.md': { id: 'original', updatedAt: 20, order: 4 } }
+    const [t] = buildLeafTargets({
+      entries: [{ path: '.agasteer/notes/a/Hello.md', type: 'blob', sha: 's1' }],
+      basePath: '.agasteer/notes',
+      metadata,
+      noteMap,
+    })
+    expect(t.leafMeta.id).toBe('original')
+  })
+})
+
+describe('getLeafPriority', () => {
+  const sets = { leafPaths: new Set(['a/Title.md']), noteIds: new Set(['note-2']) }
+
+  it('returns 0 for a URL-specified leaf', () => {
+    expect(getLeafPriority(makeTarget(), sets)).toBe(0)
+  })
+
+  it('returns 1 for a leaf under a specified note', () => {
+    expect(getLeafPriority(makeTarget({ relativePath: 'x.md', noteId: 'note-2' }), sets)).toBe(1)
+  })
+
+  it('returns 2 otherwise', () => {
+    expect(getLeafPriority(makeTarget({ relativePath: 'x.md', noteId: 'note-9' }), sets)).toBe(2)
+  })
+})
+
+describe('buildLeafFromTarget', () => {
+  it('builds a Leaf with the target metadata, content, and blobSha', () => {
+    const leaf = buildLeafFromTarget(makeTarget(), 'body', 'blob-sha')
+    expect(leaf).toEqual({
+      id: 'leaf-1',
+      title: 'Title',
+      noteId: 'note-1',
+      content: 'body',
+      updatedAt: 111,
+      order: 0,
+      badgeIcon: undefined,
+      badgeColor: undefined,
+      blobSha: 'blob-sha',
+    })
   })
 })

--- a/src/lib/api/github/pull-map.ts
+++ b/src/lib/api/github/pull-map.ts
@@ -1,10 +1,16 @@
 /**
- * GitHub Pull のパス折り畳み（純粋層）
+ * GitHub Pull のパス折り畳み・スケルトン構築（純粋層）
  *
  * fetch・settings・IO に一切触れない純粋関数のみを置く。
  * github.ts から純移動（Phase 3 / #226）。振る舞いは不変。
+ *
+ * pullFromGitHub / pullArchive で重複していた
+ * 「tree レスポンス → notes/leaves スケルトン構築」ロジックを集約する。
+ * noteMap を mutate する現状ロジックはそのまま保存し、
+ * 非決定性（uuid / Date.now）は optional 引数で注入可能にする（デフォルトは現状維持）。
  */
 
+import type { Leaf, Metadata, Note } from '../../types'
 import { sanitizePathPart } from './paths'
 
 /**
@@ -15,4 +21,156 @@ import { sanitizePathPart } from './paths'
 export function collapseToTwoLevels(parts: string[]): string[] {
   if (parts.length <= 2) return parts.map((p) => sanitizePathPart(p))
   return [sanitizePathPart(parts[0]), sanitizePathPart(parts.slice(1).join('/'))]
+}
+
+/** tree レスポンスの blob/tree エントリ */
+export interface TreeEntry {
+  path: string
+  type: string
+  sha: string
+}
+
+/** metadata.leaves の値の型（リーフのメタ情報） */
+export type LeafMeta = Metadata['leaves'][string]
+
+/**
+ * リーフ取得ターゲット（コンテンツ取得前に確定するスケルトン情報）。
+ * pullFromGitHub / pullArchive で共通の形状。
+ */
+export interface LeafTarget {
+  entry: TreeEntry
+  title: string
+  noteId: string
+  leafMeta: LeafMeta
+  relativePath: string
+}
+
+/**
+ * ノートパスを noteMap に登録し、末端ノートの id を返す。
+ *
+ * pathParts は内部で collapseToTwoLevels される（呼び出し側の現状挙動を保存）。
+ * meta.notes に partial パスの id があればそれを使い、無ければ idGenerator で新規生成する。
+ * noteMap は引数で受けて **mutate** する（現状ロジックそのまま）。
+ */
+export function ensureNotePath(params: {
+  pathParts: string[]
+  noteMap: Map<string, Note>
+  metadata: Metadata
+  idGenerator?: () => string
+}): string {
+  const { pathParts, noteMap, metadata, idGenerator = () => crypto.randomUUID() } = params
+  const collapsed = collapseToTwoLevels(pathParts)
+  let parentId: string | undefined
+  for (let i = 0; i < collapsed.length; i++) {
+    const partial = collapsed.slice(0, i + 1).join('/')
+    if (noteMap.has(partial)) {
+      parentId = noteMap.get(partial)!.id
+      continue
+    }
+    // metadata.jsonからメタ情報を取得
+    const meta = metadata.notes[partial] || {
+      id: idGenerator(),
+      order: noteMap.size,
+      badgeIcon: undefined,
+      badgeColor: undefined,
+    }
+    const note: Note = {
+      id: meta.id,
+      name: collapsed[i],
+      parentId,
+      order: meta.order,
+      badgeIcon: meta.badgeIcon,
+      badgeColor: meta.badgeColor,
+    }
+    noteMap.set(partial, note)
+    parentId = note.id
+  }
+  return parentId || ''
+}
+
+/**
+ * .md エントリ群から LeafTarget[] を構築する。
+ *
+ * ファイル名を先に分離してからノートパス部分だけを collapse し、
+ * metadata.leaves を collapsed / original の2キーで引き当てる（現状の順序を保存）。
+ * 内部で ensureNotePath を呼び noteMap を **mutate** する。
+ * idGenerator / now は注入可能（デフォルトは現状維持）。
+ */
+export function buildLeafTargets(params: {
+  entries: TreeEntry[]
+  basePath: string
+  metadata: Metadata
+  noteMap: Map<string, Note>
+  idGenerator?: () => string
+  now?: () => number
+}): LeafTarget[] {
+  const {
+    entries,
+    basePath,
+    metadata,
+    noteMap,
+    idGenerator = () => crypto.randomUUID(),
+    now = () => Date.now(),
+  } = params
+  const basePathRegExp = new RegExp(`^${basePath}/`)
+  return entries.map((entry, idx) => {
+    const relativePath = entry.path.replace(basePathRegExp, '')
+    const allParts = relativePath.split('/').filter(Boolean)
+    // ファイル名を先に分離してから、ノートパス部分だけをcollapseする
+    const fileName = allParts.pop() || ''
+    const noteParts = collapseToTwoLevels(allParts)
+    const title = fileName.replace(/\.md$/i, '') || 'Untitled'
+    const noteId = ensureNotePath({ pathParts: noteParts, noteMap, metadata, idGenerator })
+    const leafPathOriginal = entry.path.replace(basePathRegExp, '')
+    const leafPathCollapsed = [...noteParts, fileName].join('/')
+    const leafMeta = metadata.leaves[leafPathCollapsed] ||
+      metadata.leaves[leafPathOriginal] || {
+        id: idGenerator(),
+        updatedAt: now(),
+        order: idx,
+        badgeIcon: undefined,
+        badgeColor: undefined,
+      }
+    return {
+      entry,
+      title,
+      noteId,
+      leafMeta,
+      relativePath: leafPathCollapsed,
+    }
+  })
+}
+
+/**
+ * リーフの取得優先度を返す（pullFromGitHub 専用）。
+ * 0: URLで指定されたリーフ / 1: 指定リーフと同じノート配下 / 2: その他。
+ */
+export function getLeafPriority(
+  target: LeafTarget,
+  priority: { leafPaths: Set<string>; noteIds: Set<string> }
+): 0 | 1 | 2 {
+  // 第1優先: URLで指定されたリーフ
+  if (priority.leafPaths.has(target.relativePath)) return 0
+  // 第2優先: URLで指定されたリーフと同じノート配下
+  if (priority.noteIds.has(target.noteId)) return 1
+  // その他
+  return 2
+}
+
+/**
+ * LeafTarget + content + blobSha から Leaf を構築する。
+ * cached / fetched の両経路で同形の Leaf を組み立てる重複を解消する。
+ */
+export function buildLeafFromTarget(target: LeafTarget, content: string, blobSha: string): Leaf {
+  return {
+    id: target.leafMeta.id,
+    title: target.title,
+    noteId: target.noteId,
+    content,
+    updatedAt: target.leafMeta.updatedAt,
+    order: target.leafMeta.order,
+    badgeIcon: target.leafMeta.badgeIcon,
+    badgeColor: target.leafMeta.badgeColor,
+    blobSha,
+  }
 }


### PR DESCRIPTION
## 関連 Issue
Refs #226（Phase 3 の PR-2。PR-3=push tree 構築は別 PR）

## 背景
`pullFromGitHub` と `pullArchive` は tree レスポンス → notes/leaves スケルトン構築のロジックがほぼ完全に重複していた。この重複を pull-map.ts に集約する（振る舞い不変・公開 API 不変の純移動＋重複解消）。安全網は #231 characterization。

## 変更内容
- **pull-map.ts**（18→178行）— `ensureNotePath` / `buildLeafTargets`（+ `LeafTarget` 型）/ `getLeafPriority` / `buildLeafFromTarget` を追加。両 pull 関数から呼ぶ。
- **github.ts**（1955→**1818行**）— 完全重複していた ensureNotePath 定義・leafTargets map・Leaf 構築（cached/fetched）を削除し呼び出しに差し替え。
- **noteMap は mutate 保存**（immutable 化せずロジック変更リスク回避）。**uuid/Date.now は optional 引数・デフォルトで本番挙動不変**（テストからのみ固定値注入）。
- 副作用オーケストレーション（priority1Completed カウント・onLeaf/onLeafFetched 発火・failedLeafPaths 追跡）は github.ts に残置。共有は getLeafPriority のみ。
- 直接単体テスト12件新設。architecture.md 更新。

## 振る舞い不変の根拠
github-pull.characterization（pull/pullArchive の golden path・分岐・優先度・unicode・blob sha cache、afterEach の assertDrained で fetch 回数 pin）40件が**無改変で全緑**＝fetch 回数・順序・コールバック発火順が不変。

## テスト
- `npx vitest run src/lib/api/github`: 200 passed
- `npm test`（全体）: 756 passed / 3 skipped
- svelte-check: 0 errors / prettier: clean