### PR TITLE
docs: raw URLブランチ固定とfetchMedia default branch追従の不変条件を明文化

### DIFF
--- a/src/lib/api/__tests__/media.characterization.test.ts
+++ b/src/lib/api/__tests__/media.characterization.test.ts
@@ -971,6 +971,10 @@ describe('resolveMedia', () => {
     expect(console.error).not.toHaveBeenCalled()
   })
 
+  // #264: 下の call!.url の完全一致アサーションは、raw URL のブランチセグメント
+  // （常に main）が ref クエリパラメータとしてこの fetch に付かないこと（=
+  // fetchMedia は常に default branch を対象にする構造的契約）も併せて固定化する。
+  // URL に `?ref=main` 等が付けば厳密一致が崩れて検知できる。
   it('解決順3: 両ミスなら Contents API を raw Accept + 認証付きで fetch し cache に書く', async () => {
     mock.on('GET', `/repos/owner/repo-media/contents/${RAW_PATH}`, { text: 'REMOTE' })
     const media = await loadMedia()

--- a/src/lib/api/__tests__/media.characterization.test.ts
+++ b/src/lib/api/__tests__/media.characterization.test.ts
@@ -1090,6 +1090,22 @@ describe('fetchMedia', () => {
     expect(res).not.toHaveProperty('httpStatus')
     expect(console.error).toHaveBeenCalledWith('fetchMedia failed:', expect.anything())
   })
+
+  // #264 の構造的契約（parsed.branch を ref に付けない = 常に default branch を
+  // 取りに行く）を守るテスト。resolveMedia の「解決順3」テストは pending/cache
+  // 層を経由する間接テストなので、こちらは fetchMedia を直接呼ぶ最小構成にして
+  // 重複を避ける。
+  it('リクエスト URL は ref・クエリパラメータを一切付けず default branch を対象にする（#264 構造的契約）', async () => {
+    mock.on('GET', `/repos/owner/repo-media/contents/${RAW_PATH}`, { text: 'REMOTE' })
+    const media = await loadMedia()
+
+    const res = await media.fetchMedia(RAW_URL, makeSettings())
+
+    expect(res.ok).toBe(true)
+    const call = mock.firstCall('GET', `/repos/owner/repo-media/contents/${RAW_PATH}`)
+    expect(call!.url).toBe(`https://api.github.com/repos/owner/repo-media/contents/${RAW_PATH}`)
+    mock.assertDrained()
+  })
 })
 
 // ============================================

--- a/src/lib/api/media.ts
+++ b/src/lib/api/media.ts
@@ -448,14 +448,17 @@ export function initMediaOnlineRetry(getSettings: () => Settings): () => void {
 /**
  * raw URL のメディアを認証付きで取得する。
  * raw URL をパースして Contents API（Accept: application/vnd.github.raw）経由で取る。
- * branch は指定せず default branch を使う（auto_init 作成直後は main）。
+ * branch は指定せず default branch を使う（auto_init 作成直後でも default branch は
+ * アカウント設定依存。詳細下記）。
  *
  * 構造的契約（#264）: `parseRawMediaUrl(url)` が返す `parsed.branch`（raw URL の
  * ブランチセグメント。常に `main`）は**意図的にこの fetch に使わない**（ref
  * パラメータを付けない・git ref としても渡さない）。このリクエストは常にリポの
  * default branch を対象にする。アップロード（PUT contents・branch 未指定）・
  * 一覧（git/trees/HEAD）も同じく default branch 追従なので、今はブランチが
- * 一致していて壊れていない。
+ * 一致していて壊れていない（第三の経路として `collapseMediaHistory`
+ * （`media/history.ts`）は `recordMediaDefaultBranch` で捕捉した実際の default
+ * branch 名を明示的に git ref API へ渡す方式で、同じく追従している）。
  *
  * 警告: 将来 `parsed.branch` を ref パラメータや git ref としてこの fetch に
  * 使うよう「修正」しないこと。メディアリポは `POST /user/repos` + auto_init で

--- a/src/lib/api/media.ts
+++ b/src/lib/api/media.ts
@@ -449,6 +449,19 @@ export function initMediaOnlineRetry(getSettings: () => Settings): () => void {
  * raw URL のメディアを認証付きで取得する。
  * raw URL をパースして Contents API（Accept: application/vnd.github.raw）経由で取る。
  * branch は指定せず default branch を使う（auto_init 作成直後は main）。
+ *
+ * 構造的契約（#264）: `parseRawMediaUrl(url)` が返す `parsed.branch`（raw URL の
+ * ブランチセグメント。常に `main`）は**意図的にこの fetch に使わない**（ref
+ * パラメータを付けない・git ref としても渡さない）。このリクエストは常にリポの
+ * default branch を対象にする。アップロード（PUT contents・branch 未指定）・
+ * 一覧（git/trees/HEAD）も同じく default branch 追従なので、今はブランチが
+ * 一致していて壊れていない。
+ *
+ * 警告: 将来 `parsed.branch` を ref パラメータや git ref としてこの fetch に
+ * 使うよう「修正」しないこと。メディアリポは `POST /user/repos` + auto_init で
+ * 作られ、default branch はユーザーの GitHub 設定依存（古いアカウントは
+ * master のままの場合がある）。`parsed.branch`（常に main）を渡すと、
+ * default branch が master のアカウントで 404 になる。
  */
 export async function fetchMedia(url: string, settings: Settings): Promise<MediaFetchResult> {
   if (!isMediaConfigured(settings)) {
@@ -462,6 +475,8 @@ export async function fetchMedia(url: string, settings: Settings): Promise<Media
     // parseRawMediaUrl が安全文字に絞っているが、防御の二重化としてエンコードも掛ける
     // #262: ヘッダ到着までを 30 秒で有限化（失敗時はプレビューの「再試行」UI が受ける）。
     // タイマーはヘッダ到着で解除されるため、100MB 級の本文ダウンロードは切られない
+    // #264: parsed.branch は下記 URL に使わない（ref 未指定 = default branch 追従の
+    // 構造的契約。詳細は上の関数 JSDoc）
     const res = await fetchWithTimeout(
       `https://api.github.com/repos/${parsed.repoFullName}/contents/${encodeURIComponent(parsed.path)}`,
       {

--- a/src/lib/api/media/naming.ts
+++ b/src/lib/api/media/naming.ts
@@ -99,11 +99,10 @@ export interface ParsedRawMediaUrl {
    * raw URL のブランチセグメント（常に `MEDIA_BRANCH` = `main`。上記コメント参照）。
    *
    * この値は raw URL の見た目上の識別子であり、取得側の `fetchMedia`（`media.ts`）は
-   * 取得にこの値を使わない（ref パラメータとして渡さない）。これは #264 で明文化した
-   * 構造的契約: fetchMedia は常にリポの default branch を Contents API で取りに行き、
-   * この `branch` フィールドは無視する。default branch が `master` の古いアカウントで
-   * 404 を起こさないための不変条件なので、fetchMedia 側でこの値を ref として使う
-   * ように「修正」しないこと。
+   * 取得にこの値を使わない（ref パラメータとして渡さない）。#264 で明文化した構造的
+   * 契約の詳細・この値を ref として使ってはいけない理由は `fetchMedia` の JSDoc
+   * （`media.ts`）を参照（このコメントでは再掲しない。ドリフト防止のため一次情報を
+   * 一箇所に保つ）。
    */
   branch: string
   /** リポルートからのパス（メディアはルート直下のファイル名） */

--- a/src/lib/api/media/naming.ts
+++ b/src/lib/api/media/naming.ts
@@ -95,6 +95,16 @@ export function buildRawMediaUrl(mediaRepoFullName: string, fileName: string): s
 export interface ParsedRawMediaUrl {
   /** `owner/repo` 形式 */
   repoFullName: string
+  /**
+   * raw URL のブランチセグメント（常に `MEDIA_BRANCH` = `main`。上記コメント参照）。
+   *
+   * この値は raw URL の見た目上の識別子であり、取得側の `fetchMedia`（`media.ts`）は
+   * 取得にこの値を使わない（ref パラメータとして渡さない）。これは #264 で明文化した
+   * 構造的契約: fetchMedia は常にリポの default branch を Contents API で取りに行き、
+   * この `branch` フィールドは無視する。default branch が `master` の古いアカウントで
+   * 404 を起こさないための不変条件なので、fetchMedia 側でこの値を ref として使う
+   * ように「修正」しないこと。
+   */
   branch: string
   /** リポルートからのパス（メディアはルート直下のファイル名） */
   path: string


### PR DESCRIPTION
## 関連 Issue
closes #264

## 変更内容
挙動は一切変更しない（`fetchMedia`/`buildRawMediaUrl`/`parseRawMediaUrl` のロジックは無変更）。以下を「構造的契約」として明文化した:

- `fetchMedia`（`src/lib/api/media.ts`）: raw URLのブランチセグメント（`parsed.branch`、常に`main`）を意図的にfetchへ使わない（refパラメータを付けない）ことをJSDoc＋インラインコメントで明記。将来「修正」して`parsed.branch`をrefとして渡すと、default branchが`master`の古いアカウントで404することを警告
- `ParsedRawMediaUrl.branch`（`src/lib/api/media/naming.ts`）: フィールドコメントで同じ契約をクロスリファレンス
- 既存の`resolveMedia`テスト（解決順3）に、そのURL完全一致アサーションがこの契約（refクエリパラメータが付かないこと）も暗黙に固定化していることを示すコメントを追加

## 背景
PR #263（#258 Trees API切替）レビューのaltitude指摘。メディアサブシステムはdefault branch追従（upload/fetch/一覧）とmain固定（raw URL生成）の2系統があり、今は両者が一致するため壊れていないが、将来raw URLを直接fetchする経路を足すと不整合が顕在化しうる。Issue内の3案のうち「現状維持＋明文化」を採用。

## テスト
- 既存テスト全通過（ロジック変更なし）: 767 passed / 3 skipped
- lint: 0 errors / 0 warnings