### PR TITLE
fix: 統計パネルを左ペイン固定からペイン対応に修正

### DIFF
--- a/docs/development/adr/0003-archive-world-lazy-load.md
+++ b/docs/development/adr/0003-archive-world-lazy-load.md
@@ -42,3 +42,7 @@ commit `a7de6bc`（"feat: 検索機能のアーカイブ対応を実装"、2026-
 約1時間後のcommit `7225ce5`（"feat: アーカイブ切り替え時に統計表示で進捗を可視化"、2026-01-13）で、統計側にもArchive対応が追加された。Archive専用の`archiveLeafStatsStore`が導入され（`src/lib/stores/leaf-stats.svelte.ts`）、`src/lib/app-state.svelte.ts`（494-503行目付近）の`_totalLeafCount`/`_totalLeafChars`が切り替えを判定する。ただしこの判定は「現在アクティブなペイン」ではなく**左ペインのワールド・ビュー（`leftWorld`/`leftView`）に固定**されている（`leftWorld.value === 'archive' && leftView.value === 'home'`の時のみArchive側の統計を表示）。この値は`paneStateStore`経由で左右両方の`PaneView`（`StatsPanel`）へ共有されるため、右ペインの統計表示も実際には左ペインのワールドに追従する形になっている。これはADR-0002の左右対称原則（「コードに差があればバグ」）との整合性に疑問が残る実装詳細であり、別途調査の余地がある。
 
 ただし「検索・統計はHomeのみ」という当初の決定そのものが撤回されたわけではない。Archiveが未ロードの間（ユーザーが一度もArchiveへ切り替えていない間）は検索・統計の対象外のままであり、「Archiveは実際に切り替えるまでPullしない」という本ADRの遅延ロードの前提は変わっていない。
+
+## 追記（2026-07、#290）
+
+上記の「左ペインのワールド・ビューに固定」されていた統計表示は、#290でペイン対応に修正された。`src/lib/stores/world-helpers.ts`に純粋関数`getLeafStatsForWorldView(world, view, homeStats, archiveStats)`を追加し、`PaneView.svelte`が自分自身の`paneWorld`/`currentView`（既存のペイン対応derived、`paneWorld`と同じ左右振り分けパターン）でこれを呼ぶように変更。`app-state.svelte.ts`側の左ペイン固定だった`_totalLeafCount`/`_totalLeafChars`とその公開経路（`paneStateStore`/`PaneState`型の該当フィールド）は不要になったため削除した。これによりADR-0002の左右対称原則との不整合は解消され、「別途調査の余地がある」という上記の留保は解消済み。

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -135,8 +135,6 @@
       dragOverLeafId: derivedState.dragOverLeafId,
       loadingLeafIds: appState.loadingLeafIds,
       leafSkeletonMap: appState.leafSkeletonMap,
-      totalLeafCount: derivedState.totalLeafCount,
-      totalLeafChars: derivedState.totalLeafChars,
       lastPulledPushCount: lastPulledPushCount.value,
       currentPriorityLeaf: derivedState.currentPriorityLeaf,
       currentOfflineLeaf: derivedState.currentOfflineLeaf,

--- a/src/components/layout/PaneView.svelte
+++ b/src/components/layout/PaneView.svelte
@@ -33,6 +33,9 @@
     focusedPane,
     leftInitialLine,
     rightInitialLine,
+    leafStatsStore,
+    archiveLeafStatsStore,
+    getLeafStatsForWorldView,
   } from '../../lib/stores'
 
   // ビューコンポーネント
@@ -117,6 +120,10 @@
   // ペインのワールドに応じてノート・リーフストアを切り替え
   let paneWorld = $derived(pane === 'left' ? paneState.value.leftWorld : paneState.value.rightWorld)
   let isArchiveWorld = $derived(paneWorld === 'archive')
+  // ペインのワールド・ビューに応じてリーフ統計を切り替え（#290: 右ペインが左ペインのワールドに追従していたバグの修正）
+  let paneLeafStats = $derived(
+    getLeafStatsForWorldView(paneWorld, currentView, leafStatsStore, archiveLeafStatsStore)
+  )
   let activeNotes = $derived(isArchiveWorld ? archiveNotes.value : notes.value)
   let activeLeaves = $derived(isArchiveWorld ? archiveLeaves.value : leaves.value)
   let activeRootNotes = $derived(
@@ -274,8 +281,8 @@
 
 {#if currentView === 'home'}
   <StatsPanel
-    leafCount={paneState.value.totalLeafCount}
-    leafCharCount={paneState.value.totalLeafChars}
+    leafCount={paneLeafStats.totalLeafCount}
+    leafCharCount={paneLeafStats.totalLeafChars}
     pushCount={paneState.value.lastPulledPushCount}
   />
 {/if}

--- a/src/lib/app-state.svelte.ts
+++ b/src/lib/app-state.svelte.ts
@@ -26,13 +26,10 @@ import {
   isPulling,
   isPushing,
   isPushingBackground,
-  leftView,
-  rightView,
   githubConfigured,
   metadata,
   dragStore,
   leafStatsStore,
-  archiveLeafStatsStore,
   moveModalStore,
   pullProgressInfo,
   offlineLeafStore,
@@ -489,18 +486,7 @@ let _draggedLeaf = $derived(dragStore.draggedLeaf)
 let _dragOverNoteId = $derived(dragStore.dragOverNoteId)
 let _dragOverLeafId = $derived(dragStore.dragOverLeafId)
 
-// leafStatsStoreとmoveModalStoreへのリアクティブアクセス
-// 左ペインのワールドとビューに応じて統計を切り替え
-let _totalLeafCount = $derived(
-  leftWorld.value === 'archive' && leftView.value === 'home'
-    ? archiveLeafStatsStore.totalLeafCount
-    : leafStatsStore.totalLeafCount
-)
-let _totalLeafChars = $derived(
-  leftWorld.value === 'archive' && leftView.value === 'home'
-    ? archiveLeafStatsStore.totalLeafChars
-    : leafStatsStore.totalLeafChars
-)
+// moveModalStoreへのリアクティブアクセス
 let _moveModalOpen = $derived(moveModalStore.isOpen)
 let _moveTargetLeaf = $derived(moveModalStore.targetLeaf)
 let _moveTargetNote = $derived(moveModalStore.targetNote)
@@ -575,12 +561,6 @@ export const derivedState = {
   get dragOverLeafId() {
     return _dragOverLeafId
   },
-  get totalLeafCount() {
-    return _totalLeafCount
-  },
-  get totalLeafChars() {
-    return _totalLeafChars
-  },
   get moveModalOpen() {
     return _moveModalOpen
   },
@@ -650,8 +630,6 @@ let _paneState = $state<PaneState>({
   dragOverLeafId: null,
   loadingLeafIds: new Set(),
   leafSkeletonMap: new Map(),
-  totalLeafCount: 0,
-  totalLeafChars: 0,
   lastPulledPushCount: 0,
   currentPriorityLeaf: null,
   currentOfflineLeaf: null,

--- a/src/lib/stores/context.ts
+++ b/src/lib/stores/context.ts
@@ -114,8 +114,6 @@ export interface PaneState {
   dragOverLeafId: string | null
   loadingLeafIds: Set<string>
   leafSkeletonMap: Map<string, any>
-  totalLeafCount: number
-  totalLeafChars: number
   lastPulledPushCount: number
   currentPriorityLeaf: Leaf | null
   currentOfflineLeaf: Leaf | null

--- a/src/lib/stores/world-helpers.test.ts
+++ b/src/lib/stores/world-helpers.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+
+import { getLeafStatsForWorldView } from './world-helpers'
+import type { Leaf, Note, View } from '../types'
+
+// leaf-stats.svelte.ts はモジュール内で $state を使うため、他のテスト（leaf-stats.test.ts）
+// 同様に localStorage をスタブしてから動的 import する。
+const localStorageStore = new Map<string, string>()
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => localStorageStore.get(k) ?? null,
+  setItem: (k: string, v: string) => void localStorageStore.set(k, v),
+  removeItem: (k: string) => void localStorageStore.delete(k),
+  clear: () => localStorageStore.clear(),
+  key: (i: number) => Array.from(localStorageStore.keys())[i] ?? null,
+  get length() {
+    return localStorageStore.size
+  },
+}
+
+const { leafStatsStore, archiveLeafStatsStore } = await import('./leaf-stats.svelte')
+
+function makeLeaf(id: string, content: string): Leaf {
+  return {
+    id,
+    noteId: 'note-1',
+    title: id,
+    content,
+    order: 0,
+  } as Leaf
+}
+
+const notes: Note[] = [{ id: 'note-1', name: 'Note', parentId: null, order: 0 }]
+
+describe('getLeafStatsForWorldView', () => {
+  const homeStats = { label: 'home' }
+  const archiveStats = { label: 'archive' }
+
+  it('[正常系] world=home, view=home のとき homeStats を返す', () => {
+    expect(getLeafStatsForWorldView('home', 'home', homeStats, archiveStats)).toBe(homeStats)
+  })
+
+  it('[正常系/同値分割] world=home, view=edit のとき homeStats を返す（home ワールドは view によらず home 統計）', () => {
+    expect(getLeafStatsForWorldView('home', 'edit', homeStats, archiveStats)).toBe(homeStats)
+  })
+
+  it('[決定表] world=archive, view=home のとき archiveStats を返す', () => {
+    expect(getLeafStatsForWorldView('archive', 'home', homeStats, archiveStats)).toBe(
+      archiveStats
+    )
+  })
+
+  it('[決定表/バグ再発防止の核] world=archive, view=edit のとき archiveStats ではなく homeStats を返す（#290: 「archiveなら常にarchiveStats」という単純化ミスの検出）', () => {
+    expect(getLeafStatsForWorldView('archive', 'edit', homeStats, archiveStats)).toBe(homeStats)
+  })
+
+  it.each<View>(['settings', 'note', 'preview', 'media'])(
+    '[同値分割の網羅] world=archive, view=%s のとき homeStats を返す（home ビュー以外は常に home 統計）',
+    (view) => {
+      expect(getLeafStatsForWorldView('archive', view, homeStats, archiveStats)).toBe(homeStats)
+    }
+  )
+
+  it.each(['Home', 'homepage'])(
+    '[境界値相当] view に近似文字列 "%s" を注入しても archiveStats に化けず homeStats のまま（厳密一致の保証）',
+    (fakeView) => {
+      expect(
+        getLeafStatsForWorldView('archive', fakeView as unknown as View, homeStats, archiveStats)
+      ).toBe(homeStats)
+    }
+  )
+
+  it('[異常系] homeStats/archiveStats に undefined を渡しても例外を投げず undefined をそのまま返す', () => {
+    expect(() =>
+      getLeafStatsForWorldView<undefined>('archive', 'home', undefined, undefined)
+    ).not.toThrow()
+    expect(getLeafStatsForWorldView<undefined>('archive', 'home', undefined, undefined)).toBeUndefined()
+  })
+
+  it('[異常系] homeStats/archiveStats に null を渡しても例外を投げず null をそのまま返す', () => {
+    expect(() => getLeafStatsForWorldView<null>('home', 'home', null, null)).not.toThrow()
+    expect(getLeafStatsForWorldView<null>('home', 'home', null, null)).toBeNull()
+  })
+
+  it('[状態遷移] world を home→archive→home と連続で呼び直しても都度正しい方に切り替わる', () => {
+    expect(getLeafStatsForWorldView('home', 'home', homeStats, archiveStats)).toBe(homeStats)
+    expect(getLeafStatsForWorldView('archive', 'home', homeStats, archiveStats)).toBe(archiveStats)
+    expect(getLeafStatsForWorldView('home', 'home', homeStats, archiveStats)).toBe(homeStats)
+  })
+
+  it('[並行実行/コア回帰・最重要] 同一のhomeStats/archiveStats参照で左(home)・右(archive)を同時に呼び出しても互いに独立している（#290 本体）', () => {
+    const leftResult = getLeafStatsForWorldView('home', 'home', homeStats, archiveStats)
+    const rightResult = getLeafStatsForWorldView('archive', 'home', homeStats, archiveStats)
+    expect(leftResult).toBe(homeStats)
+    expect(rightResult).toBe(archiveStats)
+    expect(leftResult).not.toBe(rightResult)
+  })
+
+  it('[並行実行/コア回帰] 左右を入れ替えたケース（左archive/右home）でも互いに独立している', () => {
+    const leftResult = getLeafStatsForWorldView('archive', 'home', homeStats, archiveStats)
+    const rightResult = getLeafStatsForWorldView('home', 'home', homeStats, archiveStats)
+    expect(leftResult).toBe(archiveStats)
+    expect(rightResult).toBe(homeStats)
+    expect(leftResult).not.toBe(rightResult)
+  })
+
+  it('[汎用性] T が number でもそのまま選択される', () => {
+    expect(getLeafStatsForWorldView('home', 'home', 1, 2)).toBe(1)
+    expect(getLeafStatsForWorldView('archive', 'home', 1, 2)).toBe(2)
+  })
+
+  it('[汎用性] T が配列でもそのまま選択される（参照同一性を保つ）', () => {
+    const homeArr = [1, 2, 3]
+    const archiveArr = [4, 5, 6]
+    expect(getLeafStatsForWorldView('archive', 'home', homeArr, archiveArr)).toBe(archiveArr)
+    expect(getLeafStatsForWorldView('archive', 'edit', homeArr, archiveArr)).toBe(homeArr)
+  })
+
+  it('[汎用性] T がオブジェクトでもそのまま選択される（参照同一性を保つ）', () => {
+    const homeObj = { totalLeafCount: 1 }
+    const archiveObj = { totalLeafCount: 2 }
+    expect(getLeafStatsForWorldView('home', 'edit', homeObj, archiveObj)).toBe(homeObj)
+  })
+})
+
+describe('PaneView 相当の合成ロジック（実ストア統合・#290 回帰防止）', () => {
+  beforeEach(() => {
+    leafStatsStore.reset()
+    archiveLeafStatsStore.reset()
+  })
+
+  it('[統合/最重要] archive側だけrebuildしても、left(home)側の解決結果はhomeStats経由のままで値が変化しない', () => {
+    const homeLeaves = [makeLeaf('h1', 'aaaaa')]
+    leafStatsStore.rebuild(homeLeaves, notes)
+
+    // PaneView.svelte と同一の呼び出し式を左右2セットで再現
+    // left: world='home', right: world='archive'（どちらも currentView は 'home' 相当）
+    const view: View = 'home'
+    const left = getLeafStatsForWorldView('home', view, leafStatsStore, archiveLeafStatsStore)
+    const right = getLeafStatsForWorldView('archive', view, leafStatsStore, archiveLeafStatsStore)
+
+    expect(left).toBe(leafStatsStore)
+    expect(right).toBe(archiveLeafStatsStore)
+    expect(left.totalLeafCount).toBe(1)
+    expect(left.totalLeafChars).toBe('aaaaa'.length)
+
+    // archive側だけ値を変える
+    const archiveLeaves = [makeLeaf('a1', 'bb'), makeLeaf('a2', 'cccc')]
+    archiveLeafStatsStore.rebuild(archiveLeaves, notes)
+
+    // right(archive) 側は更新されるが、left(home) 側の解決結果は無関係のまま
+    expect(right.totalLeafCount).toBe(2)
+    expect(left.totalLeafCount).toBe(1)
+    expect(left.totalLeafChars).toBe('aaaaa'.length)
+  })
+})

--- a/src/lib/stores/world-helpers.test.ts
+++ b/src/lib/stores/world-helpers.test.ts
@@ -44,9 +44,7 @@ describe('getLeafStatsForWorldView', () => {
   })
 
   it('[決定表] world=archive, view=home のとき archiveStats を返す', () => {
-    expect(getLeafStatsForWorldView('archive', 'home', homeStats, archiveStats)).toBe(
-      archiveStats
-    )
+    expect(getLeafStatsForWorldView('archive', 'home', homeStats, archiveStats)).toBe(archiveStats)
   })
 
   it('[決定表/バグ再発防止の核] world=archive, view=edit のとき archiveStats ではなく homeStats を返す（#290: 「archiveなら常にarchiveStats」という単純化ミスの検出）', () => {
@@ -73,7 +71,9 @@ describe('getLeafStatsForWorldView', () => {
     expect(() =>
       getLeafStatsForWorldView<undefined>('archive', 'home', undefined, undefined)
     ).not.toThrow()
-    expect(getLeafStatsForWorldView<undefined>('archive', 'home', undefined, undefined)).toBeUndefined()
+    expect(
+      getLeafStatsForWorldView<undefined>('archive', 'home', undefined, undefined)
+    ).toBeUndefined()
   })
 
   it('[異常系] homeStats/archiveStats に null を渡しても例外を投げず null をそのまま返す', () => {

--- a/src/lib/stores/world-helpers.ts
+++ b/src/lib/stores/world-helpers.ts
@@ -3,7 +3,7 @@
  * ストアに依存しない純粋関数として定義
  */
 
-import type { Note, Leaf, WorldType } from '../types'
+import type { Note, Leaf, WorldType, View } from '../types'
 import type { Pane } from '../navigation'
 
 /**
@@ -90,4 +90,16 @@ export function getWorldForLeaf(leaf: Leaf, homeLeaves: Leaf[], archiveLeaves: L
  */
 export function getDialogPositionForPane(pane: Pane): 'bottom-left' | 'bottom-right' {
   return pane === 'left' ? 'bottom-left' : 'bottom-right'
+}
+
+/**
+ * ワールド・ビューに応じたリーフ統計を取得（Archiveワールドかつhomeビューの時だけArchive側の統計）
+ */
+export function getLeafStatsForWorldView<T>(
+  world: WorldType,
+  view: View,
+  homeStats: T,
+  archiveStats: T
+): T {
+  return world === 'archive' && view === 'home' ? archiveStats : homeStats
 }


### PR DESCRIPTION
## 関連 Issue
closes #290

## 変更内容
統計パネル（StatsPanel）が右ペインでも左ペインのワールド（Home/Archive）に追従してしまうバグを修正。ADR-0002「左右ペインを完全に対等にする」原則との不整合。

- `src/lib/stores/world-helpers.ts`: 純粋関数 `getLeafStatsForWorldView<T>(world, view, homeStats, archiveStats): T` を追加（既存の`getWorldForPane`等と同じスタイル）
- `src/components/layout/PaneView.svelte`: 既存のペイン対応derived（`paneWorld`/`currentView`）を使ってこの関数を呼び、`StatsPanel`にペイン固有の統計を渡すように変更
- `src/lib/app-state.svelte.ts` / `src/App.svelte` / `src/lib/stores/context.ts`: 左ペイン固定だった旧ロジック（`_totalLeafCount`/`_totalLeafChars`とその公開経路）を削除
- `docs/development/adr/0003-archive-world-lazy-load.md`: この非対称を「別途調査の余地がある」と記していた追記に、本PRで解消済みである旨を追記

## テスト
- 新規 `src/lib/stores/world-helpers.test.ts`（19ケース）: 純粋関数のデシジョンテーブル網羅・左右ペイン独立性の回帰ガード・実ストアを使った統合相当検証
- 全体: 798 passed / 3 skipped、デグレなし
- lint: 0 errors / 0 warnings